### PR TITLE
Add roof group draft control

### DIFF
--- a/index.html
+++ b/index.html
@@ -109,6 +109,10 @@
         <span data-i18n="roofBaseOffset">基準高さ</span>
         <input id="input-roof-base-offset" type="number" step="100" value="0">
       </label>
+      <label id="label-roof-group-id" class="grid-label">
+        <span data-i18n="roofGroupId">屋根グループ</span>
+        <input id="input-roof-group-id" type="text" value="RG1">
+      </label>
     </div>
     <div id="tool-opts-load" class="tool-opts">
       <label class="grid-label">

--- a/js/tools.js
+++ b/js/tools.js
@@ -491,12 +491,16 @@ export class ToolManager {
 
   _getRoofOptions() {
     if (!isSlopedSurfaceType(this.state.surfaceDraftType)) return {};
-    return {
+    const options = {
       roofSlope: this.state.surfaceDraftRoofSlope,
       roofDirection: this.state.surfaceDraftRoofDirection,
       roofBaseOffset: this.state.surfaceDraftRoofBaseOffset,
       includeWind: true,
     };
+    if (this.state.surfaceDraftType === 'roof') {
+      options.roofGroupId = this.state.surfaceDraftRoofGroupId || 'RG1';
+    }
+    return options;
   }
 
   _surfaceDown(e) {

--- a/js/ui.js
+++ b/js/ui.js
@@ -110,6 +110,10 @@ export class UI {
       this.state.surfaceDraftRoofBaseOffset = readNumberInput(e.target, this.state.surfaceDraftRoofBaseOffset || 0);
       e.target.value = String(this.state.surfaceDraftRoofBaseOffset);
     });
+    document.getElementById('input-roof-group-id').addEventListener('change', e => {
+      this.state.surfaceDraftRoofGroupId = String(e.target.value || '').trim() || 'RG1';
+      e.target.value = this.state.surfaceDraftRoofGroupId;
+    });
 
     // Load type
     document.getElementById('sel-load-type').addEventListener('change', e => {
@@ -175,6 +179,7 @@ export class UI {
     const type = this.state.surfaceDraftType;
     const isFloor = type === 'floor';
     const isWall = isWallSurfaceType(type);
+    const isRoof = type === 'roof';
     const isSloped = isSlopedSurfaceType(type);
     const modeLabel = document.getElementById('label-surface-mode');
     const loadDirLabel = document.getElementById('label-load-direction');
@@ -185,6 +190,7 @@ export class UI {
     const roofSlopeLabel = document.getElementById('label-roof-slope');
     const roofDirectionLabel = document.getElementById('label-roof-direction');
     const roofBaseOffsetLabel = document.getElementById('label-roof-base-offset');
+    const roofGroupLabel = document.getElementById('label-roof-group-id');
     if (modeLabel) modeLabel.style.display = (isFloor || isSloped) ? '' : 'none';
     if (loadDirLabel) loadDirLabel.style.display = isFloor ? '' : 'none';
     if (topLayerLabel) topLayerLabel.style.display = 'none';
@@ -194,6 +200,7 @@ export class UI {
     if (roofSlopeLabel) roofSlopeLabel.style.display = isSloped ? '' : 'none';
     if (roofDirectionLabel) roofDirectionLabel.style.display = isSloped ? '' : 'none';
     if (roofBaseOffsetLabel) roofBaseOffsetLabel.style.display = isSloped ? '' : 'none';
+    if (roofGroupLabel) roofGroupLabel.style.display = isRoof ? '' : 'none';
     this._syncWallHeightInputs(false);
     this._syncRoofInputs();
   }
@@ -231,9 +238,11 @@ export class UI {
     const slopeEl = document.getElementById('input-roof-slope');
     const directionEl = document.getElementById('sel-roof-direction');
     const baseOffsetEl = document.getElementById('input-roof-base-offset');
+    const groupEl = document.getElementById('input-roof-group-id');
     if (slopeEl) slopeEl.value = String(this.state.surfaceDraftRoofSlope || 0);
     if (directionEl) directionEl.value = this.state.surfaceDraftRoofDirection || 'xPlus';
     if (baseOffsetEl) baseOffsetEl.value = String(this.state.surfaceDraftRoofBaseOffset || 0);
+    if (groupEl) groupEl.value = this.state.surfaceDraftRoofGroupId || 'RG1';
   }
 
   refreshLayerSelectors() {

--- a/test/roof-draft-ui.test.js
+++ b/test/roof-draft-ui.test.js
@@ -1,0 +1,16 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('roof draft toolbar exposes roof group id and passes it into new roof surfaces', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const uiSource = await readFile(new URL('../js/ui.js', import.meta.url), 'utf8');
+  const toolsSource = await readFile(new URL('../js/tools.js', import.meta.url), 'utf8');
+
+  assert.match(html, /id="label-roof-group-id"/);
+  assert.match(html, /id="input-roof-group-id"/);
+  assert.match(uiSource, /surfaceDraftRoofGroupId = String\(e\.target\.value \|\| ''\)\.trim\(\) \|\| 'RG1'/);
+  assert.match(uiSource, /roofGroupLabel\.style\.display = isRoof \? '' : 'none'/);
+  assert.match(uiSource, /groupEl\.value = this\.state\.surfaceDraftRoofGroupId \|\| 'RG1'/);
+  assert.match(toolsSource, /options\.roofGroupId = this\.state\.surfaceDraftRoofGroupId \|\| 'RG1'/);
+});


### PR DESCRIPTION
## Summary

- add a roof group id control to the surface draft toolbar for new roof surfaces
- keep the control hidden for eaves while preserving shared slope controls
- pass the draft roof group id explicitly into newly created roof surfaces

## Validation
- npm test
- npm run lint:all







