### PR TITLE
Apply exterior wall silhouettes to rectangles

### DIFF
--- a/js/quantities.js
+++ b/js/quantities.js
@@ -137,8 +137,11 @@ export function computeSurfaceWindProjectionM2(state, surface) {
   const { height } = resolveSurfaceVerticalRange(state, surface);
   if (height <= 0) return { xAreaM2: 0, yAreaM2: 0 };
 
-  if (surface.type === 'exteriorWall' && surface.shape === 'polygon' && Array.isArray(surface.points) && surface.points.length >= 3) {
-    return computeExteriorWallPolygonWindProjectionM2(surface, height);
+  if (surface.type === 'exteriorWall' && (
+    surface.shape === 'rect' ||
+    (surface.shape === 'polygon' && Array.isArray(surface.points) && surface.points.length >= 3)
+  )) {
+    return computeExteriorWallWindProjectionM2(surface, height);
   }
 
   let xAreaMm2 = 0;
@@ -190,7 +193,7 @@ function computeGableWallWindProjectionM2(state, surface) {
   };
 }
 
-function computeExteriorWallPolygonWindProjectionM2(surface, height) {
+function computeExteriorWallWindProjectionM2(surface, height) {
   const segments = surfacePlanSegments(surface);
   return {
     xAreaM2: projectedSegmentUnionLengthMm(segments, 'y') * height * MM2_TO_M2,

--- a/test/quantity-summary.test.js
+++ b/test/quantity-summary.test.js
@@ -325,6 +325,16 @@ test('wind projection uses direction-specific projected areas', () => {
     xAreaM2: 11.2,
     yAreaM2: 14,
   });
+
+  const rectExterior = state.addSurfaceRect(0, 0, 5000, 4000, {
+    type: 'exteriorWall',
+    levelId: 'L0',
+    topLevelId: 'L1',
+  });
+  assert.deepEqual(computeSurfaceWindProjectionM2(state, rectExterior), {
+    xAreaM2: 11.2,
+    yAreaM2: 14,
+  });
 });
 
 test('exterior wall polygon wind projection uses the segment silhouette once per axis', async () => {
@@ -348,7 +358,7 @@ test('exterior wall polygon wind projection uses the segment silhouette once per
   });
 
   const quantitiesSource = await readFile(new URL('../js/quantities.js', import.meta.url), 'utf8');
-  assert.match(quantitiesSource, /computeExteriorWallPolygonWindProjectionM2/);
+  assert.match(quantitiesSource, /computeExteriorWallWindProjectionM2/);
   assert.match(quantitiesSource, /projectedSegmentUnionLengthMm\(segments,\s*'y'\)/);
   assert.match(quantitiesSource, /projectedSegmentUnionLengthMm\(segments,\s*'x'\)/);
   assert.doesNotMatch(quantitiesSource, /pointBounds/);


### PR DESCRIPTION
## Summary

- apply exterior-wall silhouette projection to rectangular exteriorWall surfaces
- keep line walls on the existing per-segment projection path

## Validation
- npm test
- npm run lint:all
