### PR TITLE
Share plan geometry helpers

### DIFF
--- a/js/geometry-utils.js
+++ b/js/geometry-utils.js
@@ -1,0 +1,78 @@
+// geometry-utils.js - small shared 2D geometry helpers
+
+export const GEOMETRY_EPS = 1e-6;
+
+export function pointToSegmentDistance(point, start, end) {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const len2 = dx * dx + dy * dy;
+  if (len2 <= GEOMETRY_EPS) return Math.hypot(point.x - start.x, point.y - start.y);
+  const t = Math.max(0, Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / len2));
+  return Math.hypot(point.x - (start.x + dx * t), point.y - (start.y + dy * t));
+}
+
+export function signedArea2(points) {
+  let area2 = 0;
+  for (let i = 0; i < points.length; i++) {
+    const a = points[i];
+    const b = points[(i + 1) % points.length];
+    area2 += a.x * b.y - b.x * a.y;
+  }
+  return area2;
+}
+
+export function polygonVertexCentroid(points) {
+  const sum = points.reduce((acc, point) => ({
+    x: acc.x + point.x,
+    y: acc.y + point.y,
+  }), { x: 0, y: 0 });
+  return {
+    x: sum.x / points.length,
+    y: sum.y / points.length,
+  };
+}
+
+export function pointInPolygon(point, polygon) {
+  let inside = false;
+  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
+    const a = polygon[i];
+    const b = polygon[j];
+    const crosses = (a.y > point.y) !== (b.y > point.y);
+    if (!crosses) continue;
+    const xAtY = ((b.x - a.x) * (point.y - a.y)) / ((b.y - a.y) || GEOMETRY_EPS) + a.x;
+    if (point.x < xAtY) inside = !inside;
+  }
+  return inside;
+}
+
+export function pointOnPolygonBoundary(point, polygon, tolerance = GEOMETRY_EPS) {
+  return polygon.some((start, index) => {
+    const end = polygon[(index + 1) % polygon.length];
+    return pointToSegmentDistance(point, start, end) <= tolerance;
+  });
+}
+
+export function pointInPolygonInterior(point, polygon, tolerance = GEOMETRY_EPS) {
+  if (pointOnPolygonBoundary(point, polygon, tolerance)) return false;
+  return pointInPolygon(point, polygon);
+}
+
+export function edgeInwardNormal(start, end, polygon) {
+  const dx = end.x - start.x;
+  const dy = end.y - start.y;
+  const length = Math.hypot(dx, dy);
+  if (length <= GEOMETRY_EPS) return { x: 0, y: 0 };
+  return signedArea2(polygon) >= 0
+    ? { x: -dy / length, y: dx / length }
+    : { x: dy / length, y: -dx / length };
+}
+
+export function uniquePositiveNumbers(values, tolerance = 0.001) {
+  const numbers = [];
+  for (const value of values) {
+    if (!Number.isFinite(value) || value <= 0) continue;
+    if (numbers.some(existing => Math.abs(existing - value) <= tolerance)) continue;
+    numbers.push(value);
+  }
+  return numbers;
+}

--- a/js/roof-geometry.js
+++ b/js/roof-geometry.js
@@ -1,5 +1,7 @@
 // roof-geometry.js - shared roof plane geometry helpers
 
+import { pointInPolygonInterior } from './geometry-utils.js';
+
 const MM2_TO_M2 = 1 / 1000000;
 const ROOF_DIRECTIONS = new Set(['xPlus', 'xMinus', 'yPlus', 'yMinus']);
 const EPS = 1e-6;
@@ -185,36 +187,6 @@ function linePolygonIntersections(points, normal, slope, station) {
 function addUniqueHit(hits, hit) {
   if (hits.some(existing => Math.abs(existing.t - hit.t) <= EPS)) return;
   hits.push(hit);
-}
-
-function pointInPolygonInterior(point, polygon) {
-  if (pointOnPolygonBoundary(point, polygon)) return false;
-  let inside = false;
-  for (let i = 0, j = polygon.length - 1; i < polygon.length; j = i++) {
-    const a = polygon[i];
-    const b = polygon[j];
-    const crosses = (a.y > point.y) !== (b.y > point.y);
-    if (!crosses) continue;
-    const xAtY = (b.x - a.x) * (point.y - a.y) / (b.y - a.y) + a.x;
-    if (point.x < xAtY) inside = !inside;
-  }
-  return inside;
-}
-
-function pointOnPolygonBoundary(point, polygon) {
-  return polygon.some((start, index) => {
-    const end = polygon[(index + 1) % polygon.length];
-    return pointToSegmentDist(point, start, end) <= EPS;
-  });
-}
-
-function pointToSegmentDist(point, start, end) {
-  const dx = end.x - start.x;
-  const dy = end.y - start.y;
-  const len2 = dx * dx + dy * dy;
-  if (len2 <= EPS) return Math.hypot(point.x - start.x, point.y - start.y);
-  const t = Math.max(0, Math.min(1, ((point.x - start.x) * dx + (point.y - start.y) * dy) / len2));
-  return Math.hypot(point.x - (start.x + dx * t), point.y - (start.y + dy * t));
 }
 
 function dot2(point, vector) {

--- a/js/state.js
+++ b/js/state.js
@@ -1,5 +1,11 @@
 // state.js - Data model and state management
 
+import {
+  edgeInwardNormal,
+  pointInPolygonInterior as isInteriorPlanPoint,
+  polygonVertexCentroid,
+  uniquePositiveNumbers,
+} from './geometry-utils.js';
 import { normalizeRoofDirection, roofPlanPoints, roofPoint3D, roofSlopeMemberSegments, roofVertices3D } from './roof-geometry.js';
 
 const DEFAULT_SECTION_DEFINITIONS = [
@@ -1101,7 +1107,7 @@ export class AppState {
       sameSegment(candidate.start, candidate.end, start, end, 1)
     );
     if (edge) {
-      const inward = roofEdgeInwardNormal(edge.start, edge.end, points);
+      const inward = edgeInwardNormal(edge.start, edge.end, points);
       const length = Math.hypot(edge.end.x - edge.start.x, edge.end.y - edge.start.y);
       const distances = uniquePositiveNumbers([
         Math.min(250, length * 0.25),
@@ -1114,12 +1120,12 @@ export class AppState {
           x: mid.x + inward.x * distance,
           y: mid.y + inward.y * distance,
         };
-        if (pointInPolygonInterior(sample, points)) return sample;
+        if (isInteriorPlanPoint(sample, points, 0.001)) return sample;
       }
     }
 
     const centroid = polygonVertexCentroid(points);
-    if (pointInPolygonInterior(centroid, points)) return centroid;
+    if (isInteriorPlanPoint(centroid, points, 0.001)) return centroid;
     return null;
   }
 
@@ -2012,58 +2018,6 @@ function sameSegment(a1, a2, b1, b2, tolerance = 1) {
 
 function pointsClose(a, b, tolerance = 1) {
   return Math.hypot(a.x - b.x, a.y - b.y) <= tolerance;
-}
-
-function roofEdgeInwardNormal(start, end, polygon) {
-  const dx = end.x - start.x;
-  const dy = end.y - start.y;
-  const length = Math.hypot(dx, dy);
-  if (length <= 0.000001) return { x: 0, y: 0 };
-  const signedArea = polygonSignedArea2(polygon);
-  return signedArea >= 0
-    ? { x: -dy / length, y: dx / length }
-    : { x: dy / length, y: -dx / length };
-}
-
-function polygonSignedArea2(points) {
-  let area2 = 0;
-  for (let i = 0; i < points.length; i++) {
-    const a = points[i];
-    const b = points[(i + 1) % points.length];
-    area2 += a.x * b.y - b.x * a.y;
-  }
-  return area2;
-}
-
-function polygonVertexCentroid(points) {
-  const sum = points.reduce((acc, point) => ({
-    x: acc.x + point.x,
-    y: acc.y + point.y,
-  }), { x: 0, y: 0 });
-  return {
-    x: sum.x / points.length,
-    y: sum.y / points.length,
-  };
-}
-
-function pointInPolygonInterior(point, points) {
-  if (points.some((start, index) => {
-    const end = points[(index + 1) % points.length];
-    return pointToSegmentDist(point.x, point.y, start.x, start.y, end.x, end.y) <= 0.001;
-  })) {
-    return false;
-  }
-  return pointInPolygon(point.x, point.y, points);
-}
-
-function uniquePositiveNumbers(values) {
-  const numbers = [];
-  for (const value of values) {
-    if (!Number.isFinite(value) || value <= 0) continue;
-    if (numbers.some(existing => Math.abs(existing - value) <= 0.001)) continue;
-    numbers.push(value);
-  }
-  return numbers;
 }
 
 function maxIdNum(items) {

--- a/test/geometry-utils.test.js
+++ b/test/geometry-utils.test.js
@@ -1,0 +1,42 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import {
+  edgeInwardNormal,
+  pointInPolygonInterior,
+  pointOnPolygonBoundary,
+  pointToSegmentDistance,
+  polygonVertexCentroid,
+  signedArea2,
+  uniquePositiveNumbers,
+} from '../js/geometry-utils.js';
+
+test('shared plan geometry helpers cover polygon interior and edge orientation', () => {
+  const polygon = [
+    { x: 0, y: 0 },
+    { x: 4000, y: 0 },
+    { x: 4000, y: 3000 },
+    { x: 0, y: 3000 },
+  ];
+
+  assert.equal(signedArea2(polygon), 24000000);
+  assert.deepEqual(polygonVertexCentroid(polygon), { x: 2000, y: 1500 });
+  assert.equal(pointToSegmentDistance({ x: 2000, y: 500 }, polygon[0], polygon[1]), 500);
+  assert.equal(pointOnPolygonBoundary({ x: 2000, y: 0 }, polygon), true);
+  assert.equal(pointInPolygonInterior({ x: 2000, y: 1500 }, polygon), true);
+  assert.equal(pointInPolygonInterior({ x: 2000, y: 0 }, polygon), false);
+  assert.deepEqual(edgeInwardNormal(polygon[0], polygon[1], polygon), { x: -0, y: 1 });
+  assert.deepEqual(uniquePositiveNumbers([250, 100, 100.0001, 10, 0, -1]), [250, 100, 10]);
+});
+
+test('roof and state modules import shared plan geometry helpers', async () => {
+  const roofGeometrySource = await readFile(new URL('../js/roof-geometry.js', import.meta.url), 'utf8');
+  const stateSource = await readFile(new URL('../js/state.js', import.meta.url), 'utf8');
+
+  assert.match(roofGeometrySource, /from '\.\/geometry-utils\.js';/);
+  assert.match(stateSource, /from '\.\/geometry-utils\.js';/);
+  assert.doesNotMatch(roofGeometrySource, /function pointInPolygonInterior/);
+  assert.doesNotMatch(stateSource, /function pointInPolygonInterior/);
+  assert.doesNotMatch(stateSource, /function roofEdgeInwardNormal/);
+});

--- a/test/quantity-summary.test.js
+++ b/test/quantity-summary.test.js
@@ -516,8 +516,8 @@ test('roof joint classification samples inward from the shared roof edge', async
   const stateSource = await readFile(new URL('../js/state.js', import.meta.url), 'utf8');
 
   assert.match(stateSource, /_roofInteriorSamplePoint\(surface,\s*start,\s*end\)/);
-  assert.match(stateSource, /roofEdgeInwardNormal\(edge\.start,\s*edge\.end,\s*points\)/);
-  assert.match(stateSource, /pointInPolygonInterior\(sample,\s*points\)/);
+  assert.match(stateSource, /edgeInwardNormal\(edge\.start,\s*edge\.end,\s*points\)/);
+  assert.match(stateSource, /isInteriorPlanPoint\(sample,\s*points,\s*0\.001\)/);
   assert.match(stateSource, /uniquePositiveNumbers\(\[/);
   assert.doesNotMatch(stateSource, /_roofInteriorZDelta\(surface,\s*edgePoint,\s*edgeZ\)/);
 });


### PR DESCRIPTION
## Summary

- add shared geometry-utils helpers for polygon interior, boundary, inward normals, centroid, and numeric de-duplication
- replace duplicate roof/state polygon-interior helpers with the shared module
- add unit and source-usage coverage for the shared helpers

## Validation
- npm test
- npm run lint:all







