### PR TITLE
Cache quantity summary refreshes

### DIFF
--- a/js/ui.js
+++ b/js/ui.js
@@ -14,6 +14,7 @@ export class UI {
   constructor(state, callbacks) {
     this.state = state;
     this.callbacks = callbacks;
+    this._quantitySummaryLastKey = null;
 
     this._setupToolbar();
     this.refreshLayerSelectors();
@@ -274,7 +275,7 @@ export class UI {
   }
 
   updatePropertyPanel() {
-    this._renderQuantitySummary();
+    this.refreshQuantitySummary();
     const container = document.getElementById('prop-content');
 
     if (this.state.selectedSupportId) {
@@ -1004,6 +1005,22 @@ export class UI {
     });
   }
 
+  refreshQuantitySummary({ force = false } = {}) {
+    const key = this._quantitySummaryStateKey();
+    if (!force && key === this._quantitySummaryLastKey) return;
+    this._quantitySummaryLastKey = key;
+    this._renderQuantitySummary();
+  }
+
+  _quantitySummaryStateKey() {
+    return JSON.stringify({
+      levels: this.state.levels,
+      nodes: this.state.nodes,
+      members: this.state.members,
+      surfaces: this.state.surfaces,
+    });
+  }
+
   _renderQuantitySummary() {
     const container = document.getElementById('quantity-content');
     if (!container) return;
@@ -1098,6 +1115,7 @@ export class UI {
     this.refreshLayerSelectors();
     this._updateToolUI();
     this.updateStatusBar();
+    this.refreshQuantitySummary({ force: true });
     this.updatePropertyPanel();
   }
 }

--- a/test/ui-quantity-refresh.test.js
+++ b/test/ui-quantity-refresh.test.js
@@ -1,0 +1,15 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+test('property panel refreshes quantity summary through a model signature cache', async () => {
+  const uiSource = await readFile(new URL('../js/ui.js', import.meta.url), 'utf8');
+
+  assert.match(uiSource, /this\._quantitySummaryLastKey = null;/);
+  assert.match(uiSource, /updatePropertyPanel\(\)\s*\{\s*this\.refreshQuantitySummary\(\);/);
+  assert.match(uiSource, /if \(!force && key === this\._quantitySummaryLastKey\) return;/);
+  assert.match(uiSource, /levels:\s*this\.state\.levels/);
+  assert.match(uiSource, /members:\s*this\.state\.members/);
+  assert.match(uiSource, /surfaces:\s*this\.state\.surfaces/);
+  assert.match(uiSource, /this\.refreshQuantitySummary\(\{ force: true \}\);/);
+});


### PR DESCRIPTION
## Summary
- cache quantity-summary rendering behind a model-state signature
- keep property-panel selection updates responsive without recomputing quantities when the model is unchanged
- force-refresh quantity labels on language changes

## Validation
- npm test
- npm run lint:all
