### PR TITLE
Add roof group eave generation

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -990,6 +990,53 @@ export class AppState {
     return walls;
   }
 
+  addEavesFromRoofGroup(roofGroupId, options = {}) {
+    const surfaces = this.getRoofGroupSurfaces(roofGroupId);
+    if (!surfaces.length) return [];
+
+    const nodeTolerance = sanitizeNonNegativeNumber(options.nodeTolerance, 1);
+    const depth = sanitizePositiveNumber(options.depth, 600);
+    const eaves = [];
+    for (const surface of surfaces) {
+      const points = roofPlanPoints(surface);
+      if (points.length < 3) continue;
+      for (const edge of this._roofPlanEdges(surface)) {
+        if (this._hasSharedRoofGroupEdge(surface, edge.start, edge.end, nodeTolerance)) continue;
+        if (this._hasEaveOnInnerSegment(surface.levelId, edge.start, edge.end, nodeTolerance)) continue;
+        const inward = edgeInwardNormal(edge.start, edge.end, points);
+        const outward = { x: -inward.x, y: -inward.y };
+        const outerStart = {
+          x: edge.start.x + outward.x * depth,
+          y: edge.start.y + outward.y * depth,
+        };
+        const outerEnd = {
+          x: edge.end.x + outward.x * depth,
+          y: edge.end.y + outward.y * depth,
+        };
+        const eave = this.addSurfacePolygon([
+          edge.start,
+          edge.end,
+          outerEnd,
+          outerStart,
+        ], {
+          type: 'eave',
+          levelId: surface.levelId,
+          topLevelId: surface.topLevelId || surface.levelId,
+          loadDirection: surface.loadDirection,
+          roofSlope: surface.roofSlope,
+          roofDirection: surface.roofDirection,
+          roofBaseOffset: surface.roofBaseOffset,
+          includeWind: hasOwn(options, 'includeWind') ? !!options.includeWind : true,
+          includeSeismicWeight: hasOwn(options, 'includeSeismicWeight') ? !!options.includeSeismicWeight : false,
+          unitWeight: sanitizeNonNegativeNumber(options.unitWeight, 0),
+          sectionName: options.sectionName || this.getDefaultSectionName('surface', 'eave'),
+        });
+        eaves.push(eave);
+      }
+    }
+    return eaves;
+  }
+
   listRoofGroups() {
     const groups = new Map();
     for (const surface of this.surfaces) {
@@ -1067,6 +1114,17 @@ export class AppState {
         tolerance
       )
     ));
+  }
+
+  _hasEaveOnInnerSegment(levelId, start, end, tolerance = 1) {
+    return this.surfaces.some(surface => {
+      if (!isEaveSurfaceType(surface.type) || surface.levelId !== levelId) return false;
+      const points = roofPlanPoints(surface);
+      return points.some((point, index) => {
+        const next = points[(index + 1) % points.length];
+        return sameSegment(start, end, point, next, tolerance);
+      });
+    });
   }
 
   _removeRoofEdgeMembersOnSegment(start, end, tolerance = 1) {
@@ -1992,6 +2050,10 @@ export function isRoofSurfaceType(type) {
 
 export function isGableWallSurfaceType(type) {
   return type === 'gableWall';
+}
+
+export function isEaveSurfaceType(type) {
+  return type === 'eave';
 }
 
 export function isSlopedSurfaceType(type) {

--- a/test/quantity-summary.test.js
+++ b/test/quantity-summary.test.js
@@ -733,6 +733,60 @@ test('gable wall generation skips shared and horizontal roof edges', () => {
   assert.equal(gableWalls.some(surface => surface.x1 === 10000 && surface.x2 === 10000), false);
 });
 
+test('eaves are generated from outer roof group edges and skip shared edges', () => {
+  const state = new AppState();
+  state.addSurfaceRect(0, 0, 5000, 4000, {
+    type: 'roof',
+    levelId: 'L1',
+    roofSlope: 0.3,
+    roofDirection: 'xPlus',
+    roofGroupId: 'Main',
+  });
+  state.addSurfaceRect(5000, 0, 10000, 4000, {
+    type: 'roof',
+    levelId: 'L1',
+    roofSlope: 0.3,
+    roofDirection: 'xMinus',
+    roofGroupId: 'Main',
+  });
+
+  const eaves = state.addEavesFromRoofGroup('Main', { depth: 600 });
+
+  assert.equal(eaves.length, 6);
+  assert.equal(eaves.every(surface => surface.type === 'eave'), true);
+  assert.equal(eaves.every(surface => !Object.hasOwn(surface, 'roofGroupId')), true);
+  assert.equal(eaves.some(surface =>
+    surface.points.some((point, index) => {
+      const next = surface.points[(index + 1) % surface.points.length];
+      return point.x === 5000 && next.x === 5000 && point.y === 0 && next.y === 4000;
+    })
+  ), false);
+  assert.deepEqual(eaves[0].points, [
+    { x: 0, y: 0 },
+    { x: 5000, y: 0 },
+    { x: 5000, y: -600 },
+    { x: 0, y: -600 },
+  ]);
+});
+
+test('eave generation is idempotent for an existing roof group boundary', () => {
+  const state = new AppState();
+  state.addSurfaceRect(0, 0, 5000, 4000, {
+    type: 'roof',
+    levelId: 'L1',
+    roofSlope: 0.3,
+    roofDirection: 'xPlus',
+    roofGroupId: 'Main',
+  });
+
+  const first = state.addEavesFromRoofGroup('Main', { depth: 600 });
+  const second = state.addEavesFromRoofGroup('Main', { depth: 600 });
+
+  assert.equal(first.length, 4);
+  assert.equal(second.length, 0);
+  assert.equal(state.surfaces.filter(surface => surface.type === 'eave').length, 4);
+});
+
 test('roof slope members are generated along the roof rise direction', () => {
   const state = new AppState();
   const roof = state.addSurfaceRect(0, 0, 5000, 4000, {


### PR DESCRIPTION
## Summary
- add AppState.addEavesFromRoofGroup() to create eave surfaces from non-shared roof group perimeter edges
- inherit roof slope/base metadata onto generated eave surfaces while keeping them out of roof groups
- skip existing eave inner edges so repeated generation is idempotent

## Validation
- npm test
- npm run lint:all
