### PR TITLE
Tighten eave inner edge dedupe

### DIFF
--- a/js/state.js
+++ b/js/state.js
@@ -1120,10 +1120,8 @@ export class AppState {
     return this.surfaces.some(surface => {
       if (!isEaveSurfaceType(surface.type) || surface.levelId !== levelId) return false;
       const points = roofPlanPoints(surface);
-      return points.some((point, index) => {
-        const next = points[(index + 1) % points.length];
-        return sameSegment(start, end, point, next, tolerance);
-      });
+      if (points.length < 2) return false;
+      return sameSegment(start, end, points[0], points[1], tolerance);
     });
   }
 

--- a/test/quantity-summary.test.js
+++ b/test/quantity-summary.test.js
@@ -787,6 +787,32 @@ test('eave generation is idempotent for an existing roof group boundary', () => 
   assert.equal(state.surfaces.filter(surface => surface.type === 'eave').length, 4);
 });
 
+test('eave dedupe only considers the generated inner edge', () => {
+  const state = new AppState();
+  state.addSurfaceRect(0, 0, 5000, 4000, {
+    type: 'roof',
+    levelId: 'L1',
+    roofSlope: 0.3,
+    roofDirection: 'xPlus',
+    roofGroupId: 'Main',
+  });
+  state.addSurfacePolygon([
+    { x: 0, y: -600 },
+    { x: 5000, y: -600 },
+    { x: 5000, y: 0 },
+    { x: 0, y: 0 },
+  ], {
+    type: 'eave',
+    levelId: 'L1',
+    roofSlope: 0.3,
+    roofDirection: 'xPlus',
+  });
+
+  const eaves = state.addEavesFromRoofGroup('Main', { depth: 600 });
+
+  assert.equal(eaves.length, 4);
+});
+
 test('roof slope members are generated along the roof rise direction', () => {
   const state = new AppState();
   const roof = state.addSurfaceRect(0, 0, 5000, 4000, {


### PR DESCRIPTION
## Summary
- make generated eave dedupe check the stored inner edge only
- preserve idempotent eave generation while avoiding accidental matches against unrelated eave edges
- add a regression test for non-inner matching edges

## Validation
- npm test
- npm run lint:all
