### PR TITLE
Add member end condition presets

### DIFF
--- a/README.md
+++ b/README.md
@@ -280,6 +280,7 @@ app.js ─┬─ state.js      Data model (AppState)
 - `nodes` / `levels` の `id` はJSONに保存されます
 - `members` / `surfaces` / `loads` の `id` は内部管理のみで、Export時には出力されません（Import時に再採番）
 - 旧バージョンで保存されたファイルも後方互換で読込可能
+- schemaVersion 10 以降、`endI` / `endJ` が未指定の線材はピンとして読み込まれます（明示された材端条件は保持されます）
 
 ### ユーザー定義ファイル
 

--- a/README.md
+++ b/README.md
@@ -118,7 +118,8 @@ CADデータ（図面情報）とユーザー定義（断面・バネ）は**別
 - ユーザー定義名の先頭に `_` は使用不可
 - 既定名と同名のユーザー定義は作成不可
 - 同グループ一覧で既定値・ユーザー定義を確認可能
-- ユーザー定義は登録後に「名前以外（寸法・色・メモ）」を更新可能
+- 線材の断面定義では、配置時に使う I端/J端の材端条件プリセット（ピン / 剛 / バネ）を登録可能
+- ユーザー定義は登録後に「名前以外（寸法・色・材端プリセット・メモ）」を更新可能
 - ユーザー定義は削除可能（ただし使用中の定義は削除不可）
 
 ## Keyboard Shortcuts
@@ -198,7 +199,7 @@ app.js ─┬─ state.js      Data model (AppState)
 
 ```json
 {
-  "schemaVersion": 9,
+  "schemaVersion": 10,
   "meta": {
     "name": "sample",
     "unit": "mm",
@@ -220,8 +221,8 @@ app.js ─┬─ state.js      Data model (AppState)
     { "id": "N2", "x": 5000, "y": 0, "z": 0 }
   ],
   "sectionCatalog": [
-    { "target": "member", "type": "beam", "name": "_G", "material": "steel", "b": 200, "h": 400, "color": "#666666", "memo": "", "isDefault": true },
-    { "target": "member", "type": "beam", "name": "B300x500", "material": "steel", "b": 300, "h": 500, "color": "#123456", "memo": "カスタム梁", "isDefault": false }
+    { "target": "member", "type": "beam", "name": "_G", "material": "steel", "b": 200, "h": 400, "color": "#666666", "memo": "", "defaultEndI": { "condition": "pin", "springSymbol": null }, "defaultEndJ": { "condition": "pin", "springSymbol": null }, "isDefault": true },
+    { "target": "member", "type": "beam", "name": "B300x500", "material": "steel", "b": 300, "h": 500, "color": "#123456", "memo": "カスタム梁", "defaultEndI": { "condition": "rigid", "springSymbol": null }, "defaultEndJ": { "condition": "spring", "springSymbol": "_SP" }, "isDefault": false }
   ],
   "springCatalog": [
     { "symbol": "_SP", "memo": "回転バネ", "isDefault": true }
@@ -288,7 +289,7 @@ app.js ─┬─ state.js      Data model (AppState)
 {
   "userDefinitions": true,
   "sections": [
-    { "target": "member", "type": "beam", "name": "B300x500", "material": "steel", "b": 300, "h": 500, "color": "#123456", "memo": "カスタム梁" }
+    { "target": "member", "type": "beam", "name": "B300x500", "material": "steel", "b": 300, "h": 500, "color": "#123456", "memo": "カスタム梁", "defaultEndI": { "condition": "rigid", "springSymbol": null }, "defaultEndJ": { "condition": "spring", "springSymbol": "SP1" } }
   ],
   "springs": [
     { "symbol": "SP1", "memo": "カスタムバネ" }
@@ -323,6 +324,7 @@ npm run lint:all
 主なテスト対象:
 - 断面/バネの命名ルール（先頭`_`禁止、既定名重複禁止）
 - 断面変更時の寸法・色反映
+- 線材断面の材端プリセット反映と配置済み部材の材端保持
 - CAD JSON Export時のカスタム定義除外・ID非出力
 - CAD読込時のカスタム定義保持・後方互換
 - 面材色解決の2D/3D共有ロジック（スモーク）

--- a/index.html
+++ b/index.html
@@ -274,6 +274,26 @@
               <input id="user-def-h" type="number" min="1" step="1" value="100">
             </div>
           </div>
+          <div id="user-def-end-preset-group" class="prop-row">
+            <div class="settings-group" style="flex:1;">
+              <label data-i18n="userDefDefaultEndI">I端プリセット</label>
+              <select id="user-def-endi-condition">
+                <option value="pin" data-i18n="endPin">ピン</option>
+                <option value="rigid" data-i18n="endRigid">剛</option>
+                <option value="spring" data-i18n="endSpring">バネ</option>
+              </select>
+              <select id="user-def-endi-spring" style="display:none;"></select>
+            </div>
+            <div class="settings-group" style="flex:1;">
+              <label data-i18n="userDefDefaultEndJ">J端プリセット</label>
+              <select id="user-def-endj-condition">
+                <option value="pin" data-i18n="endPin">ピン</option>
+                <option value="rigid" data-i18n="endRigid">剛</option>
+                <option value="spring" data-i18n="endSpring">バネ</option>
+              </select>
+              <select id="user-def-endj-spring" style="display:none;"></select>
+            </div>
+          </div>
           <div class="settings-group">
             <label data-i18n="userDefMemo">メモ</label>
             <input id="user-def-section-memo" type="text" placeholder="">

--- a/js/app.js
+++ b/js/app.js
@@ -163,6 +163,11 @@ const userDefNameInput = document.getElementById('user-def-name');
 const userDefColorInput = document.getElementById('user-def-color');
 const userDefBInput = document.getElementById('user-def-b');
 const userDefHInput = document.getElementById('user-def-h');
+const userDefEndPresetGroup = document.getElementById('user-def-end-preset-group');
+const userDefEndIConditionSelect = document.getElementById('user-def-endi-condition');
+const userDefEndJConditionSelect = document.getElementById('user-def-endj-condition');
+const userDefEndISpringSelect = document.getElementById('user-def-endi-spring');
+const userDefEndJSpringSelect = document.getElementById('user-def-endj-spring');
 const userDefSectionMemoInput = document.getElementById('user-def-section-memo');
 const userDefSymbolInput = document.getElementById('user-def-symbol');
 const userDefMemoInput = document.getElementById('user-def-memo');
@@ -270,6 +275,8 @@ function refreshUserDefFormVisibility() {
   if (userDefSpringGroup) userDefSpringGroup.style.display = isSection ? 'none' : '';
   const isMemberSection = isSection && userDefTargetSelect?.value === 'member';
   if (userDefSizeGroup) userDefSizeGroup.style.display = isMemberSection ? 'flex' : 'none';
+  if (userDefEndPresetGroup) userDefEndPresetGroup.style.display = isMemberSection ? 'flex' : 'none';
+  refreshUserDefEndSpringVisibility();
 }
 
 function getUserDefGroupDefaultSection(target, type) {
@@ -293,7 +300,102 @@ function applyUserDefDefaultSectionValues() {
   if (target === 'member') {
     if (userDefBInput) userDefBInput.value = String(section?.b || 200);
     if (userDefHInput) userDefHInput.value = String(section?.h || 400);
+    setUserDefEndPresetInputs(section?.defaultEndI, section?.defaultEndJ);
   }
+}
+
+function setUserDefEndPresetInputs(defaultEndI = null, defaultEndJ = null) {
+  setEndPresetInput(userDefEndIConditionSelect, userDefEndISpringSelect, defaultEndI);
+  setEndPresetInput(userDefEndJConditionSelect, userDefEndJSpringSelect, defaultEndJ);
+  refreshUserDefEndSpringVisibility();
+}
+
+function setEndPresetInput(conditionEl, springEl, endInfo = null) {
+  if (!conditionEl) return;
+  const condition = ['pin', 'rigid', 'spring'].includes(endInfo?.condition) ? endInfo.condition : 'pin';
+  conditionEl.value = condition;
+  refreshSpringSelectOptions(springEl, endInfo?.springSymbol || '');
+}
+
+function refreshSpringSelectOptions(selectEl, selectedSymbol = '') {
+  if (!selectEl) return;
+  const springs = state.listSprings();
+  const fallbackSymbol = springs[0]?.symbol || '';
+  const selected = selectedSymbol || selectEl.value || fallbackSymbol;
+  selectEl.innerHTML = springs.map(s =>
+    `<option value="${escapeHtml(s.symbol)}" ${s.symbol === selected ? 'selected' : ''}>${escapeHtml(s.symbol)}</option>`
+  ).join('');
+  if (selected && springs.some(s => s.symbol === selected)) selectEl.value = selected;
+}
+
+function refreshUserDefEndSpringVisibility() {
+  refreshSpringSelectOptions(userDefEndISpringSelect);
+  refreshSpringSelectOptions(userDefEndJSpringSelect);
+  syncEndSpringVisibility(userDefEndIConditionSelect, userDefEndISpringSelect);
+  syncEndSpringVisibility(userDefEndJConditionSelect, userDefEndJSpringSelect);
+}
+
+function syncEndSpringVisibility(conditionEl, springEl) {
+  if (!conditionEl || !springEl) return;
+  springEl.style.display = conditionEl.value === 'spring' ? '' : 'none';
+}
+
+function readEndPreset(conditionEl, springEl) {
+  const condition = conditionEl?.value || 'pin';
+  return {
+    condition,
+    springSymbol: condition === 'spring' ? (springEl?.value || null) : null,
+  };
+}
+
+function endConditionLabel(condition) {
+  if (condition === 'rigid') return t('endRigid');
+  if (condition === 'spring') return t('endSpring');
+  return t('endPin');
+}
+
+function formatEndPreset(endInfo) {
+  const condition = ['pin', 'rigid', 'spring'].includes(endInfo?.condition) ? endInfo.condition : 'pin';
+  if (condition === 'spring') {
+    return `${t('endSpring')} ${endInfo?.springSymbol || '-'}`;
+  }
+  return endConditionLabel(condition);
+}
+
+function renderEndConditionOptions(selectedCondition = 'pin') {
+  return ['pin', 'rigid', 'spring'].map(condition =>
+    `<option value="${condition}" ${condition === selectedCondition ? 'selected' : ''}>${escapeHtml(endConditionLabel(condition))}</option>`
+  ).join('');
+}
+
+function renderSpringOptions(springs, selectedSymbol = '') {
+  const selected = selectedSymbol || springs[0]?.symbol || '';
+  return springs.map(s =>
+    `<option value="${escapeHtml(s.symbol)}" ${s.symbol === selected ? 'selected' : ''}>${escapeHtml(s.symbol)}</option>`
+  ).join('');
+}
+
+function renderEndPresetCell(endInfo, fieldPrefix, editable, springs) {
+  const condition = ['pin', 'rigid', 'spring'].includes(endInfo?.condition) ? endInfo.condition : 'pin';
+  const springSymbol = endInfo?.springSymbol || springs[0]?.symbol || '';
+  if (!editable) {
+    return escapeHtml(formatEndPreset({ condition, springSymbol }));
+  }
+  return `
+    <select class="user-def-table-input" data-field="${fieldPrefix}Condition">
+      ${renderEndConditionOptions(condition)}
+    </select>
+    <select class="user-def-table-input" data-field="${fieldPrefix}Spring" style="${condition === 'spring' ? '' : 'display:none;'}">
+      ${renderSpringOptions(springs, springSymbol)}
+    </select>
+  `;
+}
+
+function readRowEndPreset(row, fieldPrefix) {
+  return readEndPreset(
+    row.querySelector(`[data-field="${fieldPrefix}Condition"]`),
+    row.querySelector(`[data-field="${fieldPrefix}Spring"]`)
+  );
 }
 
 function resetUserDefForm() {
@@ -389,6 +491,7 @@ function renderUserDefGroupList() {
   }
 
   const hasSize = target === 'member';
+  const springDefs = state.listSprings();
   userDefListBody.innerHTML = `
     <p><b>${t('userDefListGroup')}:</b> ${escapeHtml(currentUserDefGroupLabel())}</p>
     <table>
@@ -396,6 +499,7 @@ function renderUserDefGroupList() {
         <tr>
           <th>${t('userDefListColName')}</th>
           ${hasSize ? `<th>${t('userDefListColB')}</th><th>${t('userDefListColH')}</th>` : ''}
+          ${hasSize ? `<th>${t('userDefListColEndI')}</th><th>${t('userDefListColEndJ')}</th>` : ''}
           <th>${t('userDefListColColor')}</th>
           <th>${t('userDefListColMemo')}</th>
           <th>${t('userDefListColDefault')}</th>
@@ -411,7 +515,9 @@ function renderUserDefGroupList() {
     : `<input type="number" class="user-def-table-input" data-field="b" min="1" step="1" value="${Number.isFinite(s.b) ? s.b : 1}">`}</td>
             <td>${s.isDefault
     ? `${s.h ?? '-'}`
-    : `<input type="number" class="user-def-table-input" data-field="h" min="1" step="1" value="${Number.isFinite(s.h) ? s.h : 1}">`}</td>` : ''}
+    : `<input type="number" class="user-def-table-input" data-field="h" min="1" step="1" value="${Number.isFinite(s.h) ? s.h : 1}">`}</td>
+            <td>${renderEndPresetCell(s.defaultEndI, 'defaultEndI', !s.isDefault, springDefs)}</td>
+            <td>${renderEndPresetCell(s.defaultEndJ, 'defaultEndJ', !s.isDefault, springDefs)}</td>` : ''}
             <td>${s.isDefault
     ? `<span style="display:inline-block;width:14px;height:14px;border:1px solid #999;vertical-align:middle;margin-right:6px;background:${escapeHtml(s.color || '#666666')};"></span>${escapeHtml(s.color || '')}`
     : `<input type="color" class="user-def-table-input" data-field="color" value="${escapeHtml(s.color || '#666666')}">`}</td>
@@ -437,6 +543,12 @@ function renderUserDefGroupList() {
 
 function attachUserDefListHandlers() {
   if (!userDefListBody) return;
+
+  userDefListBody.querySelectorAll('[data-field$="Condition"]').forEach(conditionEl => {
+    const springField = conditionEl.dataset.field.replace('Condition', 'Spring');
+    const springEl = conditionEl.closest('td')?.querySelector(`[data-field="${springField}"]`);
+    conditionEl.addEventListener('change', () => syncEndSpringVisibility(conditionEl, springEl));
+  });
 
   userDefListBody.querySelectorAll('[data-action="save-section"]').forEach(btn => {
     btn.addEventListener('click', () => {
@@ -467,6 +579,8 @@ function attachUserDefListHandlers() {
         }
         patch.b = b;
         patch.h = h;
+        patch.defaultEndI = readRowEndPreset(row, 'defaultEndI');
+        patch.defaultEndJ = readRowEndPreset(row, 'defaultEndJ');
       }
 
       const updated = state.updateSection(target, type, name, patch);
@@ -571,7 +685,17 @@ function addUserDefinition() {
         markInputError(userDefHInput);
         return;
       }
-      added = state.addSection({ target, type, name, b, h, color, memo: sectionMemo });
+      added = state.addSection({
+        target,
+        type,
+        name,
+        b,
+        h,
+        color,
+        memo: sectionMemo,
+        defaultEndI: readEndPreset(userDefEndIConditionSelect, userDefEndISpringSelect),
+        defaultEndJ: readEndPreset(userDefEndJConditionSelect, userDefEndJSpringSelect),
+      });
     } else {
       added = state.addSection({ target, type, name, color, memo: sectionMemo });
     }
@@ -691,6 +815,7 @@ document.getElementById('file-user-def-import').addEventListener('change', async
         ? t('userDefImportedWithSkip').replace('{n}', added).replace('{s}', skipped)
         : t('userDefImported').replace('{n}', added);
       showNotice(msg, 'success');
+      refreshUserDefEndSpringVisibility();
       update();
       if (userDefListModal?.classList.contains('visible')) {
         renderUserDefGroupList();
@@ -722,6 +847,8 @@ if (userDefTypeSelect) userDefTypeSelect.addEventListener('change', () => {
   applyUserDefDefaultSectionValues();
   if (userDefListModal?.classList.contains('visible')) renderUserDefGroupList();
 });
+if (userDefEndIConditionSelect) userDefEndIConditionSelect.addEventListener('change', refreshUserDefEndSpringVisibility);
+if (userDefEndJConditionSelect) userDefEndJConditionSelect.addEventListener('change', refreshUserDefEndSpringVisibility);
 
 if (userDefModal) {
   userDefModal.addEventListener('click', (e) => {

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -170,6 +170,8 @@ const dict = {
     userDefColor: '色',
     userDefWidthB: '幅 b (mm)',
     userDefHeightH: '高さ h (mm)',
+    userDefDefaultEndI: 'I端プリセット',
+    userDefDefaultEndJ: 'J端プリセット',
     userDefMemo: 'メモ',
     userDefListOpen: '同グループ一覧',
     userDefListTitle: '同グループ定義一覧',
@@ -179,6 +181,8 @@ const dict = {
     userDefListColMaterial: '材料',
     userDefListColB: '幅 b',
     userDefListColH: '高さ h',
+    userDefListColEndI: 'I端',
+    userDefListColEndJ: 'J端',
     userDefListColColor: '色',
     userDefListColMemo: 'メモ',
     userDefListColDefault: '既定',
@@ -332,7 +336,7 @@ const dict = {
   <li><b>ユーザー定義</b> - 断面定義 / バネ定義を追加・管理</li>
   <li><b>ヘルプ</b> - この簡易マニュアルを表示</li>
 </ul>
-<p>既定の断面・バネ（例: <code>_G</code>, <code>_C</code>, <code>_S</code>, <code>_OW</code>, <code>_IW</code>, <code>_SP</code>）は編集・削除できません。ユーザー定義名の先頭に <code>_</code> は使えません。登録後は名前以外の項目（寸法・色・メモ）を更新でき、ユーザー定義は削除可能です（使用中の定義は削除できません）。</p>
+<p>既定の断面・バネ（例: <code>_G</code>, <code>_C</code>, <code>_S</code>, <code>_OW</code>, <code>_IW</code>, <code>_SP</code>）は編集・削除できません。ユーザー定義名の先頭に <code>_</code> は使えません。線材の断面定義には、配置時に使う I端/J端の材端条件プリセットを設定できます。登録後は名前以外の項目（寸法・色・材端プリセット・メモ）を更新でき、ユーザー定義は削除可能です（使用中の定義は削除できません）。</p>
 <p>「同グループ一覧」で現在のグループ定義を別画面で確認できます。</p>
 <p>「エクスポート」でユーザー定義をJSONファイルとしてダウンロード、「インポート」で別環境からユーザー定義を読み込めます。</p>
 
@@ -527,6 +531,8 @@ const dict = {
     userDefColor: 'Color',
     userDefWidthB: 'Width b (mm)',
     userDefHeightH: 'Height h (mm)',
+    userDefDefaultEndI: 'I End Preset',
+    userDefDefaultEndJ: 'J End Preset',
     userDefMemo: 'Memo',
     userDefListOpen: 'View Group List',
     userDefListTitle: 'Definition List (Group)',
@@ -536,6 +542,8 @@ const dict = {
     userDefListColMaterial: 'Material',
     userDefListColB: 'Width b',
     userDefListColH: 'Height h',
+    userDefListColEndI: 'I End',
+    userDefListColEndJ: 'J End',
     userDefListColColor: 'Color',
     userDefListColMemo: 'Memo',
     userDefListColDefault: 'Type',
@@ -689,7 +697,7 @@ const dict = {
   <li><b>User Definitions</b> - Add/manage section and spring definitions</li>
   <li><b>Help</b> - Opens this quick manual</li>
 </ul>
-<p>Default definitions (for example <code>_G</code>, <code>_C</code>, <code>_S</code>, <code>_OW</code>, <code>_IW</code>, <code>_SP</code>) cannot be edited or deleted. Custom names cannot start with <code>_</code>. After registration, fields other than name can be updated (size, color, memo), and custom definitions can be deleted unless they are currently in use.</p>
+<p>Default definitions (for example <code>_G</code>, <code>_C</code>, <code>_S</code>, <code>_OW</code>, <code>_IW</code>, <code>_SP</code>) cannot be edited or deleted. Custom names cannot start with <code>_</code>. Line section definitions can set I/J end condition presets used when placing new lines. After registration, fields other than name can be updated (size, color, end presets, memo), and custom definitions can be deleted unless they are currently in use.</p>
 <p>Use "Group List" to review registered definitions for the current group in a separate dialog.</p>
 <p>Use "Export" to download user definitions as a JSON file, and "Import" to load definitions from another environment.</p>
 

--- a/js/io.js
+++ b/js/io.js
@@ -183,7 +183,7 @@ export function importJSON(file, state, history) {
 }
 
 export function exportUserDefs(state) {
-  const sections = state.sectionCatalog.filter(s => !s.isDefault).map(s => ({ ...s }));
+  const sections = state.sectionCatalog.filter(s => !s.isDefault).map(s => cloneSectionDefinition(s));
   const springs = state.springCatalog.filter(s => !s.isDefault).map(s => ({ ...s }));
   if (sections.length === 0 && springs.length === 0) return false;
 
@@ -202,6 +202,14 @@ export function exportUserDefs(state) {
   return true;
 }
 
+function cloneSectionDefinition(section) {
+  return {
+    ...section,
+    defaultEndI: section.defaultEndI ? { ...section.defaultEndI } : undefined,
+    defaultEndJ: section.defaultEndJ ? { ...section.defaultEndJ } : undefined,
+  };
+}
+
 export function importUserDefs(file, state) {
   return new Promise((resolve, reject) => {
     const reader = new FileReader();
@@ -214,17 +222,17 @@ export function importUserDefs(file, state) {
         }
         let added = 0;
         let skipped = 0;
-        if (Array.isArray(data.sections)) {
-          for (const entry of data.sections) {
-            if (entry.isDefault) continue;
-            const result = state.addSection(entry);
-            if (result) { added++; } else { skipped++; }
-          }
-        }
         if (Array.isArray(data.springs)) {
           for (const entry of data.springs) {
             if (entry.isDefault) continue;
             const result = state.addSpring(entry);
+            if (result) { added++; } else { skipped++; }
+          }
+        }
+        if (Array.isArray(data.sections)) {
+          for (const entry of data.sections) {
+            if (entry.isDefault) continue;
+            const result = state.addSection(entry);
             if (result) { added++; } else { skipped++; }
           }
         }

--- a/js/state.js
+++ b/js/state.js
@@ -9,10 +9,10 @@ import {
 import { normalizeRoofDirection, roofPlanPoints, roofPoint3D, roofSlopeMemberSegments, roofVertices3D } from './roof-geometry.js';
 
 const DEFAULT_SECTION_DEFINITIONS = [
-  { target: 'member', type: 'beam', name: '_G', material: 'steel', b: 200, h: 400, color: '#666666', isDefault: true },
-  { target: 'member', type: 'column', name: '_C', material: 'steel', b: 105, h: 105, color: '#666666', isDefault: true },
-  { target: 'member', type: 'hbrace', name: '_H', material: 'steel', b: 20, h: 20, color: '#666666', isDefault: true },
-  { target: 'member', type: 'vbrace', name: '_V', material: 'steel', b: 20, h: 20, color: '#666666', isDefault: true },
+  { target: 'member', type: 'beam', name: '_G', material: 'steel', b: 200, h: 400, color: '#666666', defaultEndI: { condition: 'pin', springSymbol: null }, defaultEndJ: { condition: 'pin', springSymbol: null }, isDefault: true },
+  { target: 'member', type: 'column', name: '_C', material: 'steel', b: 105, h: 105, color: '#666666', defaultEndI: { condition: 'pin', springSymbol: null }, defaultEndJ: { condition: 'pin', springSymbol: null }, isDefault: true },
+  { target: 'member', type: 'hbrace', name: '_H', material: 'steel', b: 20, h: 20, color: '#666666', defaultEndI: { condition: 'pin', springSymbol: null }, defaultEndJ: { condition: 'pin', springSymbol: null }, isDefault: true },
+  { target: 'member', type: 'vbrace', name: '_V', material: 'steel', b: 20, h: 20, color: '#666666', defaultEndI: { condition: 'pin', springSymbol: null }, defaultEndJ: { condition: 'pin', springSymbol: null }, isDefault: true },
   { target: 'surface', type: 'floor', name: '_S', material: '', b: null, h: null, color: '#67a9cf', isDefault: true },
   { target: 'surface', type: 'exteriorWall', name: '_OW', material: '', b: null, h: null, color: '#b57a6b', isDefault: true },
   { target: 'surface', type: 'wall', name: '_IW', material: '', b: null, h: null, color: '#b57a6b', isDefault: true },
@@ -30,7 +30,7 @@ const DEFAULT_SPRING_SYMBOL_SET = new Set(DEFAULT_SPRING_DEFINITIONS.map(s => s.
 const END_FIXITIES = new Set(['pin', 'rigid', 'spring']);
 const MEMBER_GEOMETRY_MODES = new Set(['level', 'explicit3d']);
 const SURFACE_HEIGHT_MODES = new Set(['full', 'waist', 'hanging', 'custom']);
-const CURRENT_SCHEMA_VERSION = 9;
+const CURRENT_SCHEMA_VERSION = 10;
 const SUPPORTED_SCHEMA_VERSIONS = new Set(
   Array.from({ length: CURRENT_SCHEMA_VERSION }, (_, index) => index + 1)
 );
@@ -112,7 +112,7 @@ export class AppState {
 
   getSection(target, type, name) {
     const section = this._getSectionRef(target, type, name);
-    return section ? { ...section } : null;
+    return section ? cloneSection(section) : null;
   }
 
   listSections(target, type) {
@@ -123,7 +123,7 @@ export class AppState {
         if (a.isDefault !== b.isDefault) return a.isDefault ? -1 : 1;
         return a.name.localeCompare(b.name);
       })
-      .map(s => ({ ...s }));
+      .map(s => cloneSection(s));
   }
 
   getDefaultSectionName(target, type) {
@@ -206,7 +206,7 @@ export class AppState {
     if (this._getSectionRef(normalized.target, normalized.type, normalized.name)) return null;
     const section = { ...normalized, isDefault: false };
     this.sectionCatalog.push(section);
-    return { ...section };
+    return cloneSection(section);
   }
 
   updateSection(target, type, name, props = {}) {
@@ -222,6 +222,12 @@ export class AppState {
       }
       if (hasOwn(props, 'h')) {
         section.h = sanitizePositiveNumber(props.h, sanitizePositiveNumber(section.h, 400));
+      }
+      if (hasOwn(props, 'defaultEndI')) {
+        section.defaultEndI = normalizeSectionDefaultEnd(props.defaultEndI);
+      }
+      if (hasOwn(props, 'defaultEndJ')) {
+        section.defaultEndJ = normalizeSectionDefaultEnd(props.defaultEndJ);
       }
     }
     if (hasOwn(props, 'color')) {
@@ -245,7 +251,7 @@ export class AppState {
       }
     }
 
-    return { ...section };
+    return cloneSection(section);
   }
 
   removeSection(target, type, name) {
@@ -320,6 +326,13 @@ export class AppState {
       (m.endJ?.condition === 'spring' && m.endJ.springSymbol === symbol)
     );
     if (inUse) return false;
+    const inSectionPreset = this.sectionCatalog.some(s =>
+      s.target === 'member' && (
+        (s.defaultEndI?.condition === 'spring' && s.defaultEndI.springSymbol === symbol) ||
+        (s.defaultEndJ?.condition === 'spring' && s.defaultEndJ.springSymbol === symbol)
+      )
+    );
+    if (inSectionPreset) return false;
     this.springCatalog.splice(idx, 1);
     return true;
   }
@@ -364,6 +377,8 @@ export class AppState {
       b: sanitizePositiveNumber(b, 200),
       h: sanitizePositiveNumber(h, 400),
       color: sanitizeColor(color, defaultColorForSection('member', normalizedType)),
+      defaultEndI: { condition: 'pin', springSymbol: null },
+      defaultEndJ: { condition: 'pin', springSymbol: null },
       isDefault: false,
     };
     this.sectionCatalog.push(section);
@@ -418,6 +433,14 @@ export class AppState {
     member.color = sanitizeColor(member.color, defaultColorForSection('member', member.type));
   }
 
+  _getMemberSectionEndDefaults(member) {
+    const section = this._getSectionRef('member', member.type, member.sectionName);
+    return {
+      endI: this._normalizeMemberEnd(section?.defaultEndI),
+      endJ: this._normalizeMemberEnd(section?.defaultEndJ),
+    };
+  }
+
   _ensureSurfaceSection(surface, requestedSectionName = null) {
     const normalizedType = this._normalizeSectionType('surface', surface.type);
     const sectionName = sanitizeText(requestedSectionName || surface.sectionName);
@@ -442,8 +465,8 @@ export class AppState {
 
   _normalizeMemberEnd(endInfo) {
     const raw = endInfo || {};
-    const rawCondition = sanitizeText(raw.condition || raw.fixity || raw.type) || 'rigid';
-    const condition = END_FIXITIES.has(rawCondition) ? rawCondition : 'rigid';
+    const rawCondition = sanitizeText(raw.condition || raw.fixity || raw.type) || 'pin';
+    const condition = END_FIXITIES.has(rawCondition) ? rawCondition : 'pin';
     const defaultSpring = this.springCatalog[0]?.symbol || null;
 
     let springSymbol = null;
@@ -707,6 +730,8 @@ export class AppState {
     const id = this.nextMemberId();
     const type = options.type || 'beam';
     let sectionName = sanitizeText(options.sectionName) || '';
+    const hasEndI = hasOwn(options, 'endI');
+    const hasEndJ = hasOwn(options, 'endJ');
 
     if (!sectionName && (
       (options.b !== undefined && options.b !== null) ||
@@ -737,10 +762,13 @@ export class AppState {
       endZ: sanitizeOptionalNumber(options.endZ),
       roofRole: sanitizeText(options.roofRole) || null,
       bracePattern: options.bracePattern || 'single',
-      endI: this._normalizeMemberEnd(options.endI),
-      endJ: this._normalizeMemberEnd(options.endJ),
+      endI: { condition: 'pin', springSymbol: null },
+      endJ: { condition: 'pin', springSymbol: null },
     };
     this._ensureMemberSection(member, sectionName);
+    const endDefaults = this._getMemberSectionEndDefaults(member);
+    member.endI = this._normalizeMemberEnd(hasEndI ? options.endI : endDefaults.endI);
+    member.endJ = this._normalizeMemberEnd(hasEndJ ? options.endJ : endDefaults.endJ);
     this.members.push(member);
     return member;
   }
@@ -1929,6 +1957,14 @@ export class AppState {
       if (m.endI?.condition === 'spring' && m.endI.springSymbol) usedSymbols.add(m.endI.springSymbol);
       if (m.endJ?.condition === 'spring' && m.endJ.springSymbol) usedSymbols.add(m.endJ.springSymbol);
     }
+    for (const section of this._usedSectionCatalog()) {
+      if (section.defaultEndI?.condition === 'spring' && section.defaultEndI.springSymbol) {
+        usedSymbols.add(section.defaultEndI.springSymbol);
+      }
+      if (section.defaultEndJ?.condition === 'spring' && section.defaultEndJ.springSymbol) {
+        usedSymbols.add(section.defaultEndJ.springSymbol);
+      }
+    }
     return this.springCatalog.filter(s => s.isDefault || usedSymbols.has(s.symbol));
   }
 
@@ -2112,6 +2148,8 @@ function createDefaultSectionCatalog() {
   return DEFAULT_SECTION_DEFINITIONS.map(s => ({
     ...s,
     type: MEMBER_SECTION_TYPE_ALIAS[s.type] || s.type,
+    defaultEndI: s.defaultEndI ? { ...s.defaultEndI } : undefined,
+    defaultEndJ: s.defaultEndJ ? { ...s.defaultEndJ } : undefined,
   }));
 }
 
@@ -2138,6 +2176,10 @@ function normalizeCatalogSectionEntry(entry) {
     color: sanitizeColor(entry.color, defaultColorForSection(entry.target, type)),
     memo: sanitizeText(entry.memo) || '',
   };
+  if (entry.target === 'member') {
+    normalized.defaultEndI = normalizeSectionDefaultEnd(entry.defaultEndI || entry.endI);
+    normalized.defaultEndJ = normalizeSectionDefaultEnd(entry.defaultEndJ || entry.endJ);
+  }
   return normalized;
 }
 
@@ -2160,8 +2202,35 @@ function isSameSectionDefinition(a, b) {
       sanitizeColor(b.color, defaultColorForSection(b.target, b.type)) &&
     (a.target !== 'member' || (
       sanitizePositiveNumber(a.b, 200) === sanitizePositiveNumber(b.b, 200) &&
-      sanitizePositiveNumber(a.h, 400) === sanitizePositiveNumber(b.h, 400)
+      sanitizePositiveNumber(a.h, 400) === sanitizePositiveNumber(b.h, 400) &&
+      isSameMemberEnd(a.defaultEndI, b.defaultEndI) &&
+      isSameMemberEnd(a.defaultEndJ, b.defaultEndJ)
     ));
+}
+
+function cloneSection(section) {
+  return {
+    ...section,
+    defaultEndI: section.defaultEndI ? { ...section.defaultEndI } : undefined,
+    defaultEndJ: section.defaultEndJ ? { ...section.defaultEndJ } : undefined,
+  };
+}
+
+function normalizeSectionDefaultEnd(endInfo) {
+  const raw = endInfo || {};
+  const rawCondition = sanitizeText(raw.condition || raw.fixity || raw.type) || 'pin';
+  const condition = END_FIXITIES.has(rawCondition) ? rawCondition : 'pin';
+  if (condition !== 'spring') {
+    return { condition, springSymbol: null };
+  }
+  const springSymbol = sanitizeText(raw.springSymbol || raw.symbol) || DEFAULT_SPRING_DEFINITIONS[0]?.symbol || null;
+  return { condition, springSymbol };
+}
+
+function isSameMemberEnd(a, b) {
+  const endA = normalizeSectionDefaultEnd(a);
+  const endB = normalizeSectionDefaultEnd(b);
+  return endA.condition === endB.condition && (endA.springSymbol || null) === (endB.springSymbol || null);
 }
 
 function hasOwn(obj, key) {

--- a/js/state.js
+++ b/js/state.js
@@ -205,6 +205,7 @@ export class AppState {
     if (DEFAULT_SECTION_NAME_SET.has(normalized.name)) return null;
     if (this._getSectionRef(normalized.target, normalized.type, normalized.name)) return null;
     const section = { ...normalized, isDefault: false };
+    this._normalizeSectionEndDefaults(section);
     this.sectionCatalog.push(section);
     return cloneSection(section);
   }
@@ -224,10 +225,10 @@ export class AppState {
         section.h = sanitizePositiveNumber(props.h, sanitizePositiveNumber(section.h, 400));
       }
       if (hasOwn(props, 'defaultEndI')) {
-        section.defaultEndI = normalizeSectionDefaultEnd(props.defaultEndI);
+        section.defaultEndI = this._normalizeMemberEnd(props.defaultEndI);
       }
       if (hasOwn(props, 'defaultEndJ')) {
-        section.defaultEndJ = normalizeSectionDefaultEnd(props.defaultEndJ);
+        section.defaultEndJ = this._normalizeMemberEnd(props.defaultEndJ);
       }
     }
     if (hasOwn(props, 'color')) {
@@ -439,6 +440,18 @@ export class AppState {
       endI: this._normalizeMemberEnd(section?.defaultEndI),
       endJ: this._normalizeMemberEnd(section?.defaultEndJ),
     };
+  }
+
+  _normalizeSectionEndDefaults(section) {
+    if (section?.target !== 'member') return;
+    section.defaultEndI = this._normalizeMemberEnd(section.defaultEndI);
+    section.defaultEndJ = this._normalizeMemberEnd(section.defaultEndJ);
+  }
+
+  _normalizeSectionCatalogEndDefaults() {
+    for (const section of this.sectionCatalog) {
+      this._normalizeSectionEndDefaults(section);
+    }
   }
 
   _ensureSurfaceSection(surface, requestedSectionName = null) {
@@ -1975,7 +1988,7 @@ export class AppState {
       settings: { ...this.settings },
       levels: this.levels.map(l => ({ ...l })),
       nodes: this.nodes.map(n => ({ ...n })),
-      sectionCatalog: this._usedSectionCatalog().map(s => ({ ...s })),
+      sectionCatalog: this._usedSectionCatalog().map(s => cloneSection(s)),
       springCatalog: this._usedSpringCatalog().map(s => ({ ...s })),
       members: this.members.map(m => ({
         type: m.type,
@@ -2078,7 +2091,7 @@ export class AppState {
     this.springCatalog = this._hydrateSpringCatalog(data.springCatalog);
     for (const cs of prevCustomSections) {
       if (!this.sectionCatalog.some(s => s.target === cs.target && s.type === cs.type && s.name === cs.name)) {
-        this.sectionCatalog.push({ ...cs });
+        this.sectionCatalog.push(cloneSection(cs));
       }
     }
     for (const cs of prevCustomSprings) {
@@ -2086,6 +2099,7 @@ export class AppState {
         this.springCatalog.push({ ...cs });
       }
     }
+    this._normalizeSectionCatalogEndDefaults();
     this.members = (data.members || []).map((m, idx) =>
       this._normalizeLoadedMember({ id: m.id || `M${idx + 1}`, ...m })
     );

--- a/style.css
+++ b/style.css
@@ -438,6 +438,9 @@ body {
   padding: 2px;
   height: 26px;
 }
+.modal-body .user-def-table-input + .user-def-table-input {
+  margin-top: 4px;
+}
 .modal-body .user-def-table-btn {
   padding: 4px 8px;
   border: 1px solid var(--border);
@@ -511,7 +514,7 @@ body {
   width: min(400px, 90vw);
 }
 .modal-user-def-list {
-  width: min(760px, 94vw);
+  width: min(920px, 96vw);
 }
 .settings-group {
   display: flex;

--- a/test/quantity-summary.test.js
+++ b/test/quantity-summary.test.js
@@ -54,7 +54,7 @@ test('wall height and weight fields survive CAD serialization', () => {
   });
 
   const data = source.toJSON();
-  assert.equal(data.schemaVersion, 9);
+  assert.equal(data.schemaVersion, 10);
   assert.equal(data.surfaces[0].heightMode, 'custom');
   assert.equal(data.surfaces[0].bottomOffset, 300);
   assert.equal(data.surfaces[0].topOffset, 1800);
@@ -87,7 +87,7 @@ test('roof plane fields survive CAD serialization', () => {
   });
 
   const data = source.toJSON();
-  assert.equal(data.schemaVersion, 9);
+  assert.equal(data.schemaVersion, 10);
   assert.equal(data.surfaces[0].type, 'roof');
   assert.equal(data.surfaces[0].roofSlope, 0.25);
   assert.equal(data.surfaces[0].roofDirection, 'yMinus');
@@ -259,7 +259,7 @@ test('eave surfaces use sloped geometry without roof grouping', () => {
   });
 
   const data = source.toJSON();
-  assert.equal(data.schemaVersion, 9);
+  assert.equal(data.schemaVersion, 10);
   assert.equal(data.surfaces[0].type, 'eave');
   assert.equal(data.surfaces[0].roofSlope, 0.2);
   assert.equal(data.surfaces[0].roofDirection, 'yPlus');
@@ -333,7 +333,7 @@ test('gable wall surfaces use trapezoid area and variable top offsets', () => {
   });
 
   const data = source.toJSON();
-  assert.equal(data.schemaVersion, 9);
+  assert.equal(data.schemaVersion, 10);
   assert.equal(data.surfaces[0].type, 'gableWall');
   assert.equal(data.surfaces[0].gableStartTopOffset, 1200);
   assert.equal(data.surfaces[0].gableEndTopOffset, 2800);
@@ -525,7 +525,7 @@ test('roof edge members are generated with explicit 3D endpoints', () => {
   assert.equal(members[0].endZ, 4500);
 
   const data = state.toJSON();
-  assert.equal(data.schemaVersion, 9);
+  assert.equal(data.schemaVersion, 10);
   assert.equal(data.members[0].geometryMode, 'explicit3d');
   assert.equal(data.members[0].startZ, 3000);
   assert.equal(data.members[0].endZ, 4500);

--- a/test/state-section-rules.test.js
+++ b/test/state-section-rules.test.js
@@ -130,6 +130,28 @@ test('section end preset updates do not rewrite placed member ends', () => {
   assert.deepEqual(beam.endJ, { condition: 'pin', springSymbol: null });
 });
 
+test('removeSpring blocks springs referenced by section end presets', () => {
+  const state = new AppState();
+  state.addSpring({ symbol: 'SP_PRESET_ONLY', memo: 'preset only' });
+  state.addSection({
+    target: 'member',
+    type: 'beam',
+    name: 'B_SPRING_PRESET',
+    b: 300,
+    h: 500,
+    color: '#123456',
+    defaultEndI: { condition: 'spring', springSymbol: 'SP_PRESET_ONLY' },
+    defaultEndJ: { condition: 'pin' },
+  });
+
+  assert.equal(state.removeSpring('SP_PRESET_ONLY'), false);
+
+  state.updateSection('member', 'beam', 'B_SPRING_PRESET', {
+    defaultEndI: { condition: 'pin' },
+  });
+  assert.equal(state.removeSpring('SP_PRESET_ONLY'), true);
+});
+
 test('surface section changes update color and follow section catalog updates', () => {
   const state = new AppState();
   state.addSection({

--- a/test/state-section-rules.test.js
+++ b/test/state-section-rules.test.js
@@ -73,6 +73,63 @@ test('member section changes update dimensions and color, and direct color edit 
   assert.equal(beam.color, '#654321');
 });
 
+test('member end presets default to pin and apply only when creating members', () => {
+  const state = new AppState();
+  state.addSpring({ symbol: 'SP_PRESET', memo: 'preset spring' });
+  state.addSection({
+    target: 'member',
+    type: 'beam',
+    name: 'B_ENDS',
+    b: 300,
+    h: 500,
+    color: '#123456',
+    defaultEndI: { condition: 'rigid' },
+    defaultEndJ: { condition: 'spring', springSymbol: 'SP_PRESET' },
+  });
+
+  const defaultBeam = addBeam(state);
+  assert.deepEqual(defaultBeam.endI, { condition: 'pin', springSymbol: null });
+  assert.deepEqual(defaultBeam.endJ, { condition: 'pin', springSymbol: null });
+
+  const n1 = state.addNode(0, 1000);
+  const n2 = state.addNode(3000, 1000);
+  const presetBeam = state.addMember(n1.id, n2.id, { type: 'beam', sectionName: 'B_ENDS' });
+  assert.deepEqual(presetBeam.endI, { condition: 'rigid', springSymbol: null });
+  assert.deepEqual(presetBeam.endJ, { condition: 'spring', springSymbol: 'SP_PRESET' });
+
+  state.updateMember(defaultBeam.id, { endI: { condition: 'rigid' }, endJ: { condition: 'pin' } });
+  state.updateMember(defaultBeam.id, { sectionName: 'B_ENDS' });
+  assert.deepEqual(defaultBeam.endI, { condition: 'rigid', springSymbol: null });
+  assert.deepEqual(defaultBeam.endJ, { condition: 'pin', springSymbol: null });
+});
+
+test('section end preset updates do not rewrite placed member ends', () => {
+  const state = new AppState();
+  state.addSection({
+    target: 'member',
+    type: 'beam',
+    name: 'B_MUTATE',
+    b: 300,
+    h: 500,
+    color: '#123456',
+    defaultEndI: { condition: 'rigid' },
+    defaultEndJ: { condition: 'rigid' },
+  });
+
+  const n1 = state.addNode(0, 0);
+  const n2 = state.addNode(3000, 0);
+  const beam = state.addMember(n1.id, n2.id, { type: 'beam', sectionName: 'B_MUTATE' });
+  state.updateMember(beam.id, { endI: { condition: 'pin' }, endJ: { condition: 'pin' } });
+
+  state.updateSection('member', 'beam', 'B_MUTATE', {
+    defaultEndI: { condition: 'rigid' },
+    defaultEndJ: { condition: 'rigid' },
+  });
+
+  assert.deepEqual(beam.endI, { condition: 'pin', springSymbol: null });
+  assert.deepEqual(beam.endJ, { condition: 'pin', springSymbol: null });
+});
+
 test('surface section changes update color and follow section catalog updates', () => {
   const state = new AppState();
   state.addSection({

--- a/test/state-serialization.test.js
+++ b/test/state-serialization.test.js
@@ -46,6 +46,8 @@ test('toJSON omits runtime IDs for members, surfaces, and loads', () => {
 
 test('toJSON includes used custom definitions but excludes unused ones', () => {
   const state = new AppState();
+  state.addSpring({ symbol: 'SP1', memo: 'used spring' });
+  state.addSpring({ symbol: 'SP_UNUSED', memo: 'not used' });
   // Add two custom sections: one will be used, one will not
   state.addSection({
     target: 'member', type: 'beam', name: 'B300x500',
@@ -57,8 +59,6 @@ test('toJSON includes used custom definitions but excludes unused ones', () => {
     target: 'member', type: 'beam', name: 'B_UNUSED',
     b: 100, h: 200, color: '#aabbcc',
   });
-  state.addSpring({ symbol: 'SP1', memo: 'used spring' });
-  state.addSpring({ symbol: 'SP_UNUSED', memo: 'not used' });
 
   // Create a member using B300x500 and a spring using SP1
   const n1 = state.addNode(0, 0);
@@ -207,6 +207,38 @@ test('loadJSON backward-compat: old files with embedded custom defs still load',
   assert.deepEqual(
     state.getSection('member', 'beam', 'OLD_BEAM').defaultEndJ,
     { condition: 'pin', springSymbol: null }
+  );
+});
+
+test('loadJSON normalizes missing section preset springs to the default spring', () => {
+  const fileData = {
+    schemaVersion: 10,
+    meta: { name: 'invalid-spring-preset', unit: 'mm', createdAt: '2026-06-03T00:00:00Z' },
+    settings: { gridSize: 1000, snap: true, wallDisplayOffset: 120 },
+    levels: [{ id: 'L0', name: 'GL', z: 0 }, { id: 'L1', name: '2F', z: 2800 }],
+    nodes: [],
+    sectionCatalog: [
+      { target: 'member', type: 'beam', name: 'B_BAD_SPRING', material: 'steel', b: 300, h: 500, color: '#123456', isDefault: false, defaultEndI: { condition: 'spring', springSymbol: 'MISSING_SP' }, defaultEndJ: { condition: 'spring' } },
+    ],
+    springCatalog: [
+      { symbol: '_SP', memo: '回転バネ', isDefault: true },
+    ],
+    members: [],
+    surfaces: [],
+    loads: [],
+    supports: [],
+  };
+
+  const state = new AppState();
+  state.loadJSON(fileData);
+
+  assert.deepEqual(
+    state.getSection('member', 'beam', 'B_BAD_SPRING').defaultEndI,
+    { condition: 'spring', springSymbol: '_SP' }
+  );
+  assert.deepEqual(
+    state.getSection('member', 'beam', 'B_BAD_SPRING').defaultEndJ,
+    { condition: 'spring', springSymbol: '_SP' }
   );
 });
 

--- a/test/state-serialization.test.js
+++ b/test/state-serialization.test.js
@@ -50,6 +50,8 @@ test('toJSON includes used custom definitions but excludes unused ones', () => {
   state.addSection({
     target: 'member', type: 'beam', name: 'B300x500',
     b: 300, h: 500, color: '#123456', memo: 'used beam',
+    defaultEndI: { condition: 'rigid' },
+    defaultEndJ: { condition: 'spring', springSymbol: 'SP1' },
   });
   state.addSection({
     target: 'member', type: 'beam', name: 'B_UNUSED',
@@ -83,6 +85,8 @@ test('toJSON includes used custom definitions but excludes unused ones', () => {
   // Memo is included in the output
   const exported = data.sectionCatalog.find(s => s.name === 'B300x500');
   assert.equal(exported.memo, 'used beam');
+  assert.deepEqual(exported.defaultEndI, { condition: 'rigid', springSymbol: null });
+  assert.deepEqual(exported.defaultEndJ, { condition: 'spring', springSymbol: 'SP1' });
   const exportedSpring = data.springCatalog.find(s => s.symbol === 'SP1');
   assert.equal(exportedSpring.memo, 'used spring');
 });
@@ -93,6 +97,8 @@ test('loadJSON restores used custom definitions from CAD and preserves existing 
   source.addSection({
     target: 'member', type: 'beam', name: 'B300x500',
     b: 300, h: 500, color: '#123456',
+    defaultEndI: { condition: 'rigid' },
+    defaultEndJ: { condition: 'spring', springSymbol: '_SP' },
   });
   source.addSection({
     target: 'surface', type: 'floor', name: 'S_BLUE',
@@ -137,6 +143,14 @@ test('loadJSON restores used custom definitions from CAD and preserves existing 
   assert.equal(restored.members[0].section.b, 300);
   assert.equal(restored.members[0].section.h, 500);
   assert.equal(restored.members[0].color, '#123456');
+  assert.deepEqual(
+    restored.getSection('member', 'beam', 'B300x500').defaultEndI,
+    { condition: 'rigid', springSymbol: null }
+  );
+  assert.deepEqual(
+    restored.getSection('member', 'beam', 'B300x500').defaultEndJ,
+    { condition: 'spring', springSymbol: '_SP' }
+  );
 
   assert.equal(restored.surfaces[0].sectionName, 'S_BLUE');
   assert.equal(restored.surfaces[0].color, '#3366aa');
@@ -186,6 +200,14 @@ test('loadJSON backward-compat: old files with embedded custom defs still load',
   assert.equal(state.members[0].sectionName, 'OLD_BEAM');
   assert.equal(state.members[0].section.b, 250);
   assert.equal(state.members[0].section.h, 600);
+  assert.deepEqual(
+    state.getSection('member', 'beam', 'OLD_BEAM').defaultEndI,
+    { condition: 'pin', springSymbol: null }
+  );
+  assert.deepEqual(
+    state.getSection('member', 'beam', 'OLD_BEAM').defaultEndJ,
+    { condition: 'pin', springSymbol: null }
+  );
 });
 
 test('addSection skips duplicates already loaded from CAD file', () => {


### PR DESCRIPTION
## Summary
- Add I/J end condition presets to member section definitions, defaulting to pin.
- Apply section end presets only when placing new members; placed members keep their edited end conditions during section changes.
- Surface the presets in the user definition form and group list, and preserve them through CAD/user-definition JSON.
- Tighten preset spring validation, deep-clone section end presets during export, and document the schemaVersion 10 implicit pin default.

## Tests
- `npm test` (77 tests)
- `npm run lint:all`
- Browser check on `http://localhost:4173` for the user definition modal and group list UI.