### PR TITLE
Add resizable side panels

### DIFF
--- a/index.html
+++ b/index.html
@@ -238,6 +238,9 @@
     <button id="btn-import-trigger" title="Load CAD data">&#128194; <span data-i18n="import">CAD読込</span></button>
     <input type="file" id="file-import" accept=".json" hidden>
   </aside>
+  <div id="toolbar-resizer" class="side-resizer side-resizer-left" role="separator" aria-label="Resize toolbar" aria-orientation="vertical">
+    <button id="btn-toggle-toolbar" class="panel-toggle-btn" type="button" aria-label="Hide toolbar" title="ツールパネルを隠す">‹</button>
+  </div>
 
   <!-- Main Area -->
   <main id="main-area">
@@ -262,6 +265,9 @@
       <span id="status-version">Ver.1.0.4</span>
     </footer>
   </main>
+  <div id="property-resizer" class="side-resizer side-resizer-right" role="separator" aria-label="Resize properties" aria-orientation="vertical">
+    <button id="btn-toggle-property" class="panel-toggle-btn" type="button" aria-label="Hide properties" title="プロパティパネルを隠す">›</button>
+  </div>
 
   <!-- Right Property Panel -->
   <aside id="property-panel">

--- a/js/app.js
+++ b/js/app.js
@@ -115,6 +115,130 @@ const ui = new UI(state, {
 
 new ToolManager(canvas2d, state, history, update);
 
+// --- Side Panels ---
+
+const sidePanelConfig = {
+  toolbar: {
+    widthVar: '--toolbar-w',
+    storageWidth: 'lineframe-toolbar-width',
+    storageCollapsed: 'lineframe-toolbar-collapsed',
+    min: 112,
+    maxRatio: 0.36,
+    defaultWidth: 160,
+    button: document.getElementById('btn-toggle-toolbar'),
+    resizer: document.getElementById('toolbar-resizer'),
+    className: 'toolbar-collapsed',
+    collapsedText: '›',
+    expandedText: '‹',
+    showLabel: 'Show toolbar',
+    hideLabel: 'Hide toolbar',
+    showTitle: 'ツールパネルを表示',
+    hideTitle: 'ツールパネルを隠す',
+  },
+  property: {
+    widthVar: '--panel-w',
+    storageWidth: 'lineframe-property-panel-width',
+    storageCollapsed: 'lineframe-property-panel-collapsed',
+    min: 156,
+    maxRatio: 0.42,
+    defaultWidth: 220,
+    button: document.getElementById('btn-toggle-property'),
+    resizer: document.getElementById('property-resizer'),
+    className: 'property-collapsed',
+    collapsedText: '‹',
+    expandedText: '›',
+    showLabel: 'Show properties',
+    hideLabel: 'Hide properties',
+    showTitle: 'プロパティパネルを表示',
+    hideTitle: 'プロパティパネルを隠す',
+  },
+};
+
+function clampPanelWidth(side, width) {
+  const cfg = sidePanelConfig[side];
+  const max = Math.max(cfg.min, Math.floor(window.innerWidth * cfg.maxRatio));
+  return Math.max(cfg.min, Math.min(max, Math.round(width)));
+}
+
+function getStoredPanelWidth(cfg) {
+  const stored = Number(localStorage.getItem(cfg.storageWidth));
+  return Number.isFinite(stored) && stored > 0 ? stored : cfg.defaultWidth;
+}
+
+function applyPanelWidth(side, width, persist = true) {
+  const cfg = sidePanelConfig[side];
+  const nextWidth = clampPanelWidth(side, width);
+  document.documentElement.style.setProperty(cfg.widthVar, `${nextWidth}px`);
+  if (persist) localStorage.setItem(cfg.storageWidth, String(nextWidth));
+  requestLayoutRefresh();
+}
+
+function isPanelCollapsed(side) {
+  return document.body.classList.contains(sidePanelConfig[side].className);
+}
+
+function updatePanelToggle(side) {
+  const cfg = sidePanelConfig[side];
+  if (!cfg.button) return;
+  const collapsed = isPanelCollapsed(side);
+  cfg.button.textContent = collapsed ? cfg.collapsedText : cfg.expandedText;
+  cfg.button.setAttribute('aria-label', collapsed ? cfg.showLabel : cfg.hideLabel);
+  cfg.button.title = collapsed ? cfg.showTitle : cfg.hideTitle;
+}
+
+function setPanelCollapsed(side, collapsed) {
+  const cfg = sidePanelConfig[side];
+  document.body.classList.toggle(cfg.className, collapsed);
+  localStorage.setItem(cfg.storageCollapsed, collapsed ? '1' : '0');
+  updatePanelToggle(side);
+  requestLayoutRefresh();
+}
+
+function requestLayoutRefresh() {
+  requestAnimationFrame(() => {
+    canvas2d.resize();
+    if (viewer3d) viewer3d.resize();
+    update();
+  });
+}
+
+function initSidePanels() {
+  for (const side of Object.keys(sidePanelConfig)) {
+    const cfg = sidePanelConfig[side];
+    applyPanelWidth(side, getStoredPanelWidth(cfg), false);
+    setPanelCollapsed(side, localStorage.getItem(cfg.storageCollapsed) === '1');
+
+    cfg.button?.addEventListener('click', () => {
+      setPanelCollapsed(side, !isPanelCollapsed(side));
+    });
+
+    cfg.resizer?.addEventListener('pointerdown', (event) => {
+      if (event.target.closest('button') || isPanelCollapsed(side)) return;
+      event.preventDefault();
+      const startX = event.clientX;
+      const startWidth = getStoredPanelWidth(cfg);
+      cfg.resizer.classList.add('active');
+      document.body.classList.add('resizing-panels');
+
+      const onPointerMove = (moveEvent) => {
+        const delta = moveEvent.clientX - startX;
+        const nextWidth = side === 'toolbar' ? startWidth + delta : startWidth - delta;
+        applyPanelWidth(side, nextWidth);
+      };
+      const onPointerUp = () => {
+        cfg.resizer.classList.remove('active');
+        document.body.classList.remove('resizing-panels');
+        window.removeEventListener('pointermove', onPointerMove);
+        window.removeEventListener('pointerup', onPointerUp);
+      };
+      window.addEventListener('pointermove', onPointerMove);
+      window.addEventListener('pointerup', onPointerUp, { once: true });
+    });
+  }
+}
+
+initSidePanels();
+
 // --- View Tab Switching ---
 
 const tab2d = document.getElementById('tab-2d');

--- a/js/app.js
+++ b/js/app.js
@@ -153,6 +153,7 @@ const sidePanelConfig = {
     hideTitle: 'プロパティパネルを隠す',
   },
 };
+let layoutRefreshQueued = false;
 
 function clampPanelWidth(side, width) {
   const cfg = sidePanelConfig[side];
@@ -171,6 +172,7 @@ function applyPanelWidth(side, width, persist = true) {
   document.documentElement.style.setProperty(cfg.widthVar, `${nextWidth}px`);
   if (persist) localStorage.setItem(cfg.storageWidth, String(nextWidth));
   requestLayoutRefresh();
+  return nextWidth;
 }
 
 function isPanelCollapsed(side) {
@@ -195,7 +197,10 @@ function setPanelCollapsed(side, collapsed) {
 }
 
 function requestLayoutRefresh() {
+  if (layoutRefreshQueued) return;
+  layoutRefreshQueued = true;
   requestAnimationFrame(() => {
+    layoutRefreshQueued = false;
     canvas2d.resize();
     if (viewer3d) viewer3d.resize();
     update();
@@ -216,23 +221,27 @@ function initSidePanels() {
       if (event.target.closest('button') || isPanelCollapsed(side)) return;
       event.preventDefault();
       const startX = event.clientX;
-      const startWidth = getStoredPanelWidth(cfg);
+      const startWidth = clampPanelWidth(side, getStoredPanelWidth(cfg));
+      let currentWidth = startWidth;
       cfg.resizer.classList.add('active');
       document.body.classList.add('resizing-panels');
 
       const onPointerMove = (moveEvent) => {
         const delta = moveEvent.clientX - startX;
         const nextWidth = side === 'toolbar' ? startWidth + delta : startWidth - delta;
-        applyPanelWidth(side, nextWidth);
+        currentWidth = applyPanelWidth(side, nextWidth, false);
       };
-      const onPointerUp = () => {
+      const finishResize = () => {
+        localStorage.setItem(cfg.storageWidth, String(currentWidth));
         cfg.resizer.classList.remove('active');
         document.body.classList.remove('resizing-panels');
         window.removeEventListener('pointermove', onPointerMove);
-        window.removeEventListener('pointerup', onPointerUp);
+        window.removeEventListener('pointerup', finishResize);
+        window.removeEventListener('pointercancel', finishResize);
       };
       window.addEventListener('pointermove', onPointerMove);
-      window.addEventListener('pointerup', onPointerUp, { once: true });
+      window.addEventListener('pointerup', finishResize, { once: true });
+      window.addEventListener('pointercancel', finishResize, { once: true });
     });
   }
 }

--- a/style.css
+++ b/style.css
@@ -3,6 +3,7 @@
 :root {
   --toolbar-w: 160px;
   --panel-w: 220px;
+  --side-resizer-w: 8px;
   --status-h: 28px;
   --tab-h: 36px;
   --bg: #1e1e2e;
@@ -59,8 +60,21 @@ html, body {
 
 body {
   display: grid;
-  grid-template-columns: var(--toolbar-w) 1fr var(--panel-w);
+  grid-template-columns: var(--toolbar-w) var(--side-resizer-w) 1fr var(--side-resizer-w) var(--panel-w);
   grid-template-rows: 1fr;
+}
+body.resizing-panels {
+  cursor: col-resize;
+  user-select: none;
+}
+body.resizing-panels * {
+  cursor: col-resize !important;
+}
+body.toolbar-collapsed {
+  --toolbar-w: 0px;
+}
+body.property-collapsed {
+  --panel-w: 0px;
 }
 
 /* Toolbar */
@@ -72,6 +86,15 @@ body {
   flex-direction: column;
   gap: 6px;
   overflow-y: auto;
+  min-width: 0;
+}
+body.toolbar-collapsed #toolbar {
+  padding: 0;
+  border-right: 0;
+  overflow: hidden;
+}
+body.toolbar-collapsed #toolbar > * {
+  display: none;
 }
 #toolbar h2 {
   font-size: 12px;
@@ -129,6 +152,53 @@ body {
   bottom: 16px;
   z-index: 1400;
   width: min(360px, calc(100vw - 24px));
+}
+
+.side-resizer {
+  position: relative;
+  z-index: 5;
+  background: var(--surface);
+  cursor: col-resize;
+  touch-action: none;
+}
+.side-resizer-left {
+  border-right: 1px solid var(--border);
+}
+.side-resizer-right {
+  border-left: 1px solid var(--border);
+}
+.side-resizer::before {
+  content: "";
+  position: absolute;
+  top: 0;
+  bottom: 0;
+  left: 3px;
+  width: 2px;
+  background: rgba(137, 180, 250, 0.22);
+}
+.side-resizer:hover::before,
+.side-resizer.active::before {
+  background: var(--accent);
+}
+.panel-toggle-btn {
+  position: absolute;
+  top: 10px;
+  left: 50%;
+  transform: translateX(-50%);
+  width: 18px;
+  height: 28px;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  background: var(--surface);
+  color: var(--text);
+  cursor: pointer;
+  line-height: 1;
+  font-size: 16px;
+  padding: 0;
+}
+.panel-toggle-btn:hover {
+  border-color: var(--accent);
+  color: var(--accent);
 }
 .app-notice {
   border: 1px solid var(--border);
@@ -262,6 +332,15 @@ body {
   border-left: 1px solid var(--border);
   padding: 12px 10px;
   overflow-y: auto;
+  min-width: 0;
+}
+body.property-collapsed #property-panel {
+  padding: 0;
+  border-left: 0;
+  overflow: hidden;
+}
+body.property-collapsed #property-panel > * {
+  display: none;
 }
 #property-panel h2 {
   font-size: 12px;

--- a/test/display-workflow-smoke.test.js
+++ b/test/display-workflow-smoke.test.js
@@ -4,8 +4,12 @@ import { readFile } from 'node:fs/promises';
 
 test('display workflow controls are exposed in the toolbar and property panel', async () => {
   const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+  const css = await readFile(new URL('../style.css', import.meta.url), 'utf8');
+  const appSource = await readFile(new URL('../js/app.js', import.meta.url), 'utf8');
 
   for (const id of [
+    'toolbar-resizer',
+    'btn-toggle-toolbar',
     'sel-display-preset',
     'chk-plan-layer-selection-lock',
     'sel-3d-layer-display-mode',
@@ -21,9 +25,19 @@ test('display workflow controls are exposed in the toolbar and property panel', 
     'btn-copy-level',
     'btn-model-check',
     'model-check-content',
+    'property-resizer',
+    'btn-toggle-property',
   ]) {
     assert.match(html, new RegExp(`id="${id}"`));
   }
+
+  assert.match(css, /grid-template-columns:\s*var\(--toolbar-w\)\s+var\(--side-resizer-w\)\s+1fr\s+var\(--side-resizer-w\)\s+var\(--panel-w\)/);
+  assert.match(css, /body\.toolbar-collapsed/);
+  assert.match(css, /body\.property-collapsed/);
+  assert.match(appSource, /lineframe-toolbar-width/);
+  assert.match(appSource, /lineframe-property-panel-width/);
+  assert.match(appSource, /pointermove/);
+  assert.match(appSource, /canvas2d\.resize\(\)/);
 });
 
 test('2D drawing and selection use shared display visibility helpers', async () => {

--- a/test/display-workflow-smoke.test.js
+++ b/test/display-workflow-smoke.test.js
@@ -37,6 +37,9 @@ test('display workflow controls are exposed in the toolbar and property panel', 
   assert.match(appSource, /lineframe-toolbar-width/);
   assert.match(appSource, /lineframe-property-panel-width/);
   assert.match(appSource, /pointermove/);
+  assert.match(appSource, /pointercancel/);
+  assert.match(appSource, /layoutRefreshQueued/);
+  assert.match(appSource, /applyPanelWidth\(side,\s*nextWidth,\s*false\)/);
   assert.match(appSource, /canvas2d\.resize\(\)/);
 });
 


### PR DESCRIPTION
## Summary
- Add draggable side-panel handles between the toolbar, drawing area, and property panel.
- Add toggle buttons to hide/show the left toolbar and right property panel while keeping restore controls visible.
- Persist panel widths and collapsed states in localStorage.
- Refresh the 2D canvas and 3D viewer after panel layout changes.

## Tests
- `npm test` (88 passed)
- `npm run lint:all`
- `git diff --check`
- Browser smoke check on `http://localhost:4174` for panel controls, left/right collapse, and canvas width updates.