### PR TITLE
ユーザー定義フォームを確定ボタンまで閉じないようにする

### DIFF
--- a/js/app.js
+++ b/js/app.js
@@ -1015,16 +1015,9 @@ if (userDefTypeSelect) userDefTypeSelect.addEventListener('change', () => {
 if (userDefEndIConditionSelect) userDefEndIConditionSelect.addEventListener('change', refreshUserDefEndSpringVisibility);
 if (userDefEndJConditionSelect) userDefEndJConditionSelect.addEventListener('change', refreshUserDefEndSpringVisibility);
 
-if (userDefModal) {
-  userDefModal.addEventListener('click', (e) => {
-    if (e.target === userDefModal) hideUserDefModal();
-  });
-}
-if (userDefListModal) {
-  userDefListModal.addEventListener('click', (e) => {
-    if (e.target === userDefListModal) hideUserDefListModal();
-  });
-}
+// User definition modals intentionally do NOT close on overlay (backdrop) click.
+// These forms hold in-progress input (section/spring definitions, inline table
+// edits), so closing must require an explicit button to avoid losing input.
 
 resetUserDefForm();
 
@@ -1215,14 +1208,15 @@ layerModal.addEventListener('click', (e) => {
   if (e.target === layerModal) hideLayerModal();
 });
 
-// Close modals on Escape
+// Close modals on Escape.
+// User definition modals are intentionally excluded: they hold in-progress
+// input, and Escape is also used by the IME to cancel a conversion, so closing
+// them must require an explicit button. When a user-def modal is open, Escape
+// is swallowed so it never falls through and closes another modal underneath.
 window.addEventListener('keydown', (e) => {
   if (e.key === 'Escape') {
-    if (userDefListModal.classList.contains('visible')) {
-      hideUserDefListModal();
-      e.stopPropagation();
-    } else if (userDefModal.classList.contains('visible')) {
-      hideUserDefModal();
+    if (userDefListModal.classList.contains('visible')
+      || userDefModal.classList.contains('visible')) {
       e.stopPropagation();
     } else if (helpModal.classList.contains('visible')) {
       hideHelpModal();


### PR DESCRIPTION
## 概要
ユーザー定義（断面・バネ）の入力中に、確定前にフォームが閉じて入力内容が消えてしまう問題を修正します。

## 原因
`user-def` モーダルには、入力途中でも閉じてしまう暗黙の経路が2つありました。

1. **背景（オーバーレイ）クリックで閉じる** — 入力中に枠外を誤クリックすると閉じる
2. **Escapeキーで閉じる** — 特に日本語IMEでは変換キャンセルにEscを使うため、変換操作のつもりがモーダルごと閉じて入力が消える

どちらも、確定（追加）前の断面・バネ定義の入力内容を失わせていました。一覧モーダル側もインライン編集の入力欄を持つため同様です。

## 変更内容
- ユーザー定義モーダル・一覧モーダルの **背景クリックで閉じる挙動を削除**
- Escapeハンドラから両モーダルを **除外**（明示的な「閉じる」ボタンでのみ閉じる）
- これらが開いている間はEscapeを `stopPropagation` で握りつぶし、背後の別モーダルが閉じないようにする

ヘルプ／設定／階モーダルは従来通りEsc・背景クリックで閉じられます。

## テスト
- `npm test` … 90件すべてpass
- `npx eslint js/app.js` … 問題なし

🤖 Generated with [Claude Code](https://claude.com/claude-code)