### PR TITLE
Add initial grid frame generator

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 node_modules/
 .claude/
+.venv/

--- a/README.md
+++ b/README.md
@@ -71,6 +71,7 @@ GitHub Pages URL: _(デプロイ後にURLを記載)_
 - 軸組図ビュー（通り芯を選んで構面の立面を表示。柱・梁・ブレース・レベル線・直交通り芯）
 - 自動保存とクラッシュ復元（localStorageへ定期保存、起動時に復元確認）
 - サンプルモデル（平屋+切妻屋根 / 2階建フレーム）を設定モーダルからワンクリック読込
+- 階高・X/Yスパンのリストから、レベル・通り芯・柱・梁・GL支点を持つ初期格子フレームを一括生成
 
 ### 3D Viewer
 - 線材を断面寸法（b x h）を反映した直方体として3D表示
@@ -335,8 +336,12 @@ app.js ─┬─ state.js      Data model (AppState)
 git clone https://github.com/<your-username>/Frame2D-CAD.git
 cd Frame2D-CAD
 
+# Create a Python environment with uv
+uv venv --python 3.13
+source .venv/bin/activate
+
 # Start local server (ES Modules require HTTP)
-python3 -m http.server 8080
+python -m http.server 8080
 
 # Open in browser
 # http://localhost:8080

--- a/docs/plan-initial-grid-frame.md
+++ b/docs/plan-initial-grid-frame.md
@@ -1,0 +1,129 @@
+# 作業計画: 初期モデル生成(柱・梁グリッドフレーム構築)機能
+
+作成日: 2026-07-19
+
+## 1. 機能概要
+
+階高リスト(mm)、X方向スパンリスト(mm)、Y方向スパンリスト(mm)の 3 つを入力として、
+柱・梁の格子フレーム(レベル・通り芯・節点・柱・梁・支点)を一括生成し、**初期モデルとして現在のモデルを置き換える**機能。
+
+入力例:
+
+| 入力 | 例 | 意味 |
+|------|----|------|
+| 階高リスト | `3500, 3000, 3000` | 3 層(1F 階高 3500、2F 階高 3000、3F 階高 3000) |
+| Xスパンリスト | `6000, 6000, 5000` | X 方向 3 スパン → X 通り 4 本 |
+| Yスパンリスト | `6000, 6000` | Y 方向 2 スパン → Y 通り 3 本 |
+
+生成内容(階高数 s、Xスパン数 sx、Yスパン数 sy とする):
+
+- **レベル**: s+1 個。GL(z=0)+ 各階高の累積和で上階を作成。命名は `GL, 2F, 3F, …` 最上階は `RF`(s=1 なら GL + RF)
+- **通り芯**: X 方向 sx+1 本(`X1…`)、Y 方向 sy+1 本(`Y1…`)。スパンの累積和を座標とする
+- **柱**: 全通り交点 × 各層 = (sx+1)(sy+1)×s 本(`levelId`=下階、`topLevelId`=上階)
+- **梁**: GL を除く各レベルに X 方向 sx×(sy+1) 本 + Y 方向 sy×(sx+1) 本
+- **支点**: GL の全通り交点に固定支点(dx, dy, dz)= (sx+1)(sy+1) 個
+
+断面・材料は `addMember` のデフォルトに任せる(生成後にユーザーが編集する前提)。床・荷重・ブレースは生成しない(§6)。
+
+## 2. 既存コードの前提(調査結果)
+
+- **最も近い既存実装は `buildTwoStoryFrame`**(`js/samples.js:102-174`)。固定値版のグリッドフレーム生成そのもの。通り芯 → 柱+支点 → `findNodeAt` で節点を共有しつつ梁、という生成手順をパラメータ化すればよい
+- レベルは `{id, name, z}` の**絶対標高(mm)**で保持(`js/state.js:1616-1620` の `createDefaultLevels`、`addLevel(name, z)` は `js/state.js:1267`)→ 階高リストは累積和に変換して渡す
+- 通り芯は `{id, dir:'x'|'y', name, coord}` の**絶対座標**で保持(`addAxis(dir, name, coord)` `js/state.js:1360`)→ スパンリストも累積和に変換
+- 柱は `startNodeId === endNodeId` の同一節点 + `levelId`/`topLevelId` で表現(`js/samples.js:118`)
+- 支点は `addSupport(x, y, { levelId, dx, dy, dz })`(`js/state.js:1539`)
+- **モデル置換フロー**は `loadSample`(`js/app.js:522-536`)が雛形: `history.save()` → `state.loadJSON(生成JSON)` → `syncSettingsControls()` → `ui.refreshLevelSelectors()` → `update()` → 通知。失敗時は `history.undo()` で巻き戻し。undo 1 回で元モデルに戻る
+- サンプルビルダーは `new AppState()` に組み立てて `state.toJSON()` を返す純関数(`js/samples.js:9-12` の `buildSampleModel`)→ 生成ロジックは同形式にすると `loadSample` フローとテストをそのまま流用できる
+- モーダルの雛形は `js/axes-modal.js`(HTML は `index.html` に静的配置、`initXxxModal({state, onModelChange})` が `{show, hide}` を返し、`.visible` クラス切替 + 表示時に `[data-i18n]` をローカライズ)。`app.js:481` 付近で配線
+- サンプル読込ボタンは設定モーダル内(`index.html:373-374` の `#btn-sample-gable` / `#btn-sample-frame`)
+- i18n は `js/i18n.js` の `dict.ja` / `dict.en` 両方に同一キーで追加必須(`test/i18n-parity.test.js` が強制)
+- テストは `node --test`。生成ロジックの検証は `test/samples.test.js` が雛形(生成 → 要素数 assert → `validateModel()` で error 0 件)
+
+## 3. 仕様詳細
+
+### 3.1 生成ロジック(buildGridFrame)
+
+```js
+// js/frame-generator.js(新規)
+parseMmList(text)
+// → { ok: true, values: [3500, 3000, ...] } | { ok: false, reason: 'empty'|'invalid'|'range'|'count' }
+buildGridFrame({ storyHeights, spansX, spansY })
+// → 生成モデルの JSON(samples.js と同じく new AppState() に組み立てて toJSON() を返す)
+```
+
+**入力パース・バリデーション(parseMmList)**
+- 区切りはカンマ・空白・読点(`,`, `、`, 空白)を許容。空要素は無視
+- 各値は正の有限数であること。範囲チェック: 1〜100,000 mm
+- 個数上限: 階高 ≤ 50、スパン各方向 ≤ 100(暴走生成の防止。超過時はエラー理由 `count`)
+- 小数は許容(mm 単位のまま保持)
+
+**生成手順(buildTwoStoryFrame のパラメータ化)**
+1. `new AppState()` を作成し、デフォルトレベル(GL/2F)を階高リストに合わせて再構成
+   (GL の z=0 は維持、2F の z を storyHeights[0] に更新、3 層目以降は `addLevel`。最上階の name は `RF`)
+2. スパン累積和から `addAxis('x', 'X{i+1}', coord)` / `addAxis('y', …)` で通り芯生成
+3. 全通り交点で層ごとに `addNode` + `addMember(node.id, node.id, {type:'column', levelId, topLevelId})`、GL に `addSupport(x, y, {levelId: gl.id, dx: true, dy: true, dz: true})`
+4. GL 以外の各レベルで、隣接 X 通り間・隣接 Y 通り間に梁を生成(`findNodeAt(x, y, 1)` で柱節点を再利用、なければ `addNode`)
+5. `state.meta.name` に生成モデル名(例: `grid_frame`)を設定し `toJSON()` を返す
+
+### 3.2 UI フロー
+
+1. 設定モーダルのサンプル読込ボタン群の並びに「初期モデル生成…」ボタン(`#btn-grid-frame`)を追加
+2. クリックで生成モーダル `#grid-frame-modal` を表示。入力欄 3 つ(階高 / Xスパン / Yスパン、テキスト入力 + 単位 mm 表記)+ プレースホルダに入力例。前回入力値はモーダルを閉じても保持(モジュール内変数でよい。永続化はしない)
+3. 「生成」ボタン押下:
+   - パース失敗 → 該当欄のエラーを `showNotice` で表示(理由別メッセージ)、モーダルは閉じない
+   - **現在のモデルに節点または部材が存在する場合**は `confirm` で置換確認(サンプル読込には無い挙動だが、ユーザー作成中モデルの破壊防止のため入れる。undo で戻れる旨もメッセージに含める)
+4. `loadSample` と同じ手順で反映: `history.save()` → `state.loadJSON(buildGridFrame(...))` → `syncSettingsControls()` → `ui.refreshLevelSelectors()` → モーダル・設定モーダルを閉じる → `update()` → 完了通知(「格子フレームを生成しました(柱{c}本・梁{b}本)」)。失敗時は `history.undo()` + エラー通知
+
+### 3.3 モジュール構成
+
+| ファイル | 内容 |
+|----------|------|
+| `js/frame-generator.js`(新規) | `parseMmList` / `buildGridFrame`。DOM 非依存の純ロジック |
+| `js/grid-frame-modal.js`(新規) | `initGridFrameModal({state, history, onModelChange, syncSettingsControls, refreshLevelSelectors})`。axes-modal.js の構造を踏襲 |
+| `index.html` | `#grid-frame-modal`(modal-overlay 構造)+ 設定モーダル内 `#btn-grid-frame` |
+| `js/app.js` | `initGridFrameModal` の配線(`app.js:481` 付近、サンプルボタン配線 `app.js:538` の近くに集約) |
+
+## 4. 作業フェーズ
+
+### Phase 1: 生成ロジック(コア)
+- [x] `js/frame-generator.js` 新規作成: `parseMmList` / `buildGridFrame`(`buildTwoStoryFrame` の手順をパラメータ化)
+- [x] レベル命名規則(GL/2F/…/RF)と、デフォルトレベル(GL/2F)の z 更新処理の実装
+
+### Phase 2: 単体テスト
+- [x] `test/frame-generator.test.js` 新規作成(`test/samples.test.js` を雛形に):
+  - 3層 × 3×2 スパンで、レベル数 s+1・通り芯数・柱 (sx+1)(sy+1)s 本・梁数・支点数が式どおり
+  - 最小ケース(1層 × 1×1 スパン)の生成
+  - 柱節点の共有(梁が柱節点を再利用し、重複節点が増えないこと)
+  - `validateModel()` で severity==='error' が 0 件
+  - `parseMmList`: 区切り(カンマ/読点/空白)、負値・0・非数・範囲外・個数超過の拒否
+  - 生成 JSON を `loadJSON` → `toJSON` して往復可能なこと
+- [x] `npm test` 全通過確認
+
+### Phase 3: モーダル UI + 配線
+- [x] `index.html`: `#grid-frame-modal` 追加(axes-modal の modal-overlay 構造を踏襲、入力 3 欄 + 生成/キャンセルボタン、`data-i18n` 付与)
+- [x] `index.html`: 設定モーダルのサンプルボタン並びに `#btn-grid-frame` 追加
+- [x] `js/grid-frame-modal.js` 新規作成: 表示/非表示、入力保持、パース → 置換確認 → `loadSample` 同等の反映フロー
+- [x] `js/app.js`: 配線(依存: `history`, `syncSettingsControls`, `ui.refreshLevelSelectors`, `update`, `hideSettingsModal`)
+
+### Phase 4: i18n・仕上げ
+- [x] `js/i18n.js`: ja/en 両方にキー追加(例: `gridFrameTitle`, `gridFrameOpen`, `gridFrameStoryHeights`, `gridFrameSpansX`, `gridFrameSpansY`, `gridFrameGenerate`, `gridFrameReplaceConfirm`, `gridFrameDone`, `gridFrameInvalidInput`, `gridFrameTooMany` 等)。`test/i18n-parity.test.js` 通過確認
+- [x] `js/help-content.js`: ヘルプに操作説明追記
+- [x] 手動確認(ブラウザ): 生成 → 2D/3D 表示・レベルセレクタ・通り芯表示の反映、undo で元モデル復帰、redo、生成後の autosave、解析エクスポート・数量集計が期待どおり
+- [x] `npm test` / lint 通過 → コミット → PR 作成
+
+## 5. 影響範囲・注意点
+
+- **モデル置換方式**: `loadSample` と同じ `history.save()` + `loadJSON` 方式のため、既存の undo/redo・autosave・シリアライズにそのまま乗る。生成ロジック側で state を直接触らない(新規 AppState に組み立てる)ことで既存モデルへの副作用を根本的に排除
+- **置換確認**: 空でないモデルを上書きするため confirm を挟む(autosave 復元 `app.js:501` と同じ `confirm` パターン)
+- **レベル再構成**: デフォルトの GL/2F を消して作り直すのではなく、GL は維持・2F は z 更新とする(レベル ID の欠番や `activeLevelId='L0'` の破綻を避ける)。ただし新規 AppState 上での操作なので厳密には自由度あり — 実装時に `createDefaultLevels` との整合を確認
+- **節点共有**: 梁生成時の `findNodeAt(x, y, 1)` は同一レベル判定を持たない(節点は z を持つが柱・梁は levelId で層を表現)。`buildTwoStoryFrame` と同じ規約に従うこと(サンプルが成立している規約をそのまま踏襲)
+- **生成量の上限**: 個数上限(§3.1)により最大でも柱 50×101×101 とはならないよう、**合計部材数にも上限**(例: 20,000)を設け超過時はエラーにする — 描画・シリアライズ性能の防衛
+- **i18n パリティ**: ja/en 同時追加を厳守(テストで強制)
+
+## 6. 初期スコープ外(将来拡張)
+
+- 床(サーフェス)・荷重・ブレースの自動生成
+- 断面記号の一括指定(生成ダイアログでの柱・梁断面選択)
+- 既存モデルへの**追加**生成(置換ではなくマージ)、基準点(原点以外)の指定
+- 通り芯名のカスタム命名(A, B, C… など)
+- スパンの繰り返し記法(例: `3@6000`)

--- a/index.html
+++ b/index.html
@@ -372,9 +372,41 @@
         </div>
         <button id="btn-sample-gable" class="settings-help-btn">&#127968; <span data-i18n="sampleGable">平屋+切妻屋根</span></button>
         <button id="btn-sample-frame" class="settings-help-btn stack-gap">&#127970; <span data-i18n="sampleFrame">2階建フレーム</span></button>
+        <button id="btn-grid-frame" class="settings-help-btn stack-gap">&#9638; <span data-i18n="gridFrameOpen">初期モデル生成…</span></button>
         <hr>
         <button id="btn-open-help" class="settings-help-btn">&#10067; <span data-i18n="help">ヘルプ</span></button>
       </div>
+    </div>
+  </div>
+
+  <!-- Initial Grid Frame Modal -->
+  <div id="grid-frame-modal" class="modal-overlay" aria-hidden="true">
+    <div class="modal-content modal-settings" role="dialog" aria-modal="true" aria-labelledby="grid-frame-modal-title">
+      <div class="modal-header">
+        <h2 id="grid-frame-modal-title" data-i18n="gridFrameTitle">初期格子フレーム生成</h2>
+        <button id="btn-grid-frame-close" type="button" class="modal-close" data-i18n="helpClose">閉じる</button>
+      </div>
+      <form id="grid-frame-form" class="modal-body" novalidate>
+        <div class="settings-group">
+          <label for="grid-frame-story-heights"><span data-i18n="gridFrameStoryHeights">階高リスト</span> (mm)</label>
+          <input id="grid-frame-story-heights" type="text" inputmode="decimal" autocomplete="off" spellcheck="false"
+                 data-i18n-placeholder="gridFrameStoryHeightsPlaceholder" placeholder="3500, 3000, 3000">
+        </div>
+        <div class="settings-group">
+          <label for="grid-frame-spans-x"><span data-i18n="gridFrameSpansX">X方向スパンリスト</span> (mm)</label>
+          <input id="grid-frame-spans-x" type="text" inputmode="decimal" autocomplete="off" spellcheck="false"
+                 data-i18n-placeholder="gridFrameSpansXPlaceholder" placeholder="6000, 6000, 5000">
+        </div>
+        <div class="settings-group">
+          <label for="grid-frame-spans-y"><span data-i18n="gridFrameSpansY">Y方向スパンリスト</span> (mm)</label>
+          <input id="grid-frame-spans-y" type="text" inputmode="decimal" autocomplete="off" spellcheck="false"
+                 data-i18n-placeholder="gridFrameSpansYPlaceholder" placeholder="6000, 6000">
+        </div>
+        <div class="support-preset-row">
+          <button id="btn-grid-frame-cancel" type="button" class="support-preset-btn" data-i18n="choiceCancel">キャンセル</button>
+          <button id="btn-grid-frame-generate" type="submit" class="support-preset-btn" data-i18n="gridFrameGenerate">生成</button>
+        </div>
+      </form>
     </div>
   </div>
 

--- a/js/app.js
+++ b/js/app.js
@@ -30,6 +30,7 @@ import { initSidePanels } from './side-panels.js';
 import { initUserDefModal } from './user-def-modal.js';
 import { initLayerModal } from './layer-modal.js';
 import { initAxesModal } from './axes-modal.js';
+import { initGridFrameModal } from './grid-frame-modal.js';
 import { initComboModal } from './combo-modal.js';
 import { initElevationModal } from './elevation-modal.js';
 import { initJoinSplitModal } from './join-split-modal.js';
@@ -274,6 +275,13 @@ const ui = new UI(state, {
   },
 });
 
+// Whole-model history restores can change levels and display settings. Keep
+// their controls synchronized before ToolManager requests the next render.
+history.setOnRestore(() => {
+  syncSettingsControls();
+  ui.refreshLevelSelectors();
+});
+
 // --- Tools ---
 
 toolManager = new ToolManager(canvas2d, state, history, update, {
@@ -483,6 +491,15 @@ const axesModal = initAxesModal({
   onModelChange: update,
 });
 
+const gridFrameModal = initGridFrameModal({
+  state,
+  history,
+  onModelChange: update,
+  syncSettingsControls,
+  refreshLevelSelectors: () => ui.refreshLevelSelectors(),
+  hideSettingsModal,
+});
+
 const comboModal = initComboModal({
   state,
   onModelChange: update,
@@ -537,6 +554,7 @@ function loadSample(sampleId) {
 
 document.getElementById('btn-sample-gable')?.addEventListener('click', () => loadSample('gableHouse'));
 document.getElementById('btn-sample-frame')?.addEventListener('click', () => loadSample('twoStoryFrame'));
+document.getElementById('btn-grid-frame')?.addEventListener('click', gridFrameModal.show);
 
 document.getElementById('btn-open-combos')?.addEventListener('click', () => {
   hideSettingsModal();
@@ -569,6 +587,7 @@ function applyLang(lang) {
   ui.applyLanguage();
   if (settingsLangSelect) settingsLangSelect.value = lang;
   applyI18nTo(settingsModal);
+  gridFrameModal.applyLanguage();
   userDefModal.applyLanguage();
   layerModal.clearFormError();
 }
@@ -657,6 +676,9 @@ window.addEventListener('keydown', (e) => {
       e.stopPropagation();
     } else if (axesModal.isOpen()) {
       axesModal.hide();
+      e.stopPropagation();
+    } else if (gridFrameModal.isOpen()) {
+      gridFrameModal.hide();
       e.stopPropagation();
     } else if (comboModal.isOpen()) {
       comboModal.hide();

--- a/js/app.js
+++ b/js/app.js
@@ -665,6 +665,7 @@ helpModal.addEventListener('click', (e) => {
 // them must require an explicit button. When a user-def modal is open, Escape
 // is swallowed so it never falls through and closes another modal underneath.
 window.addEventListener('keydown', (e) => {
+  if (e.isComposing) return;
   if (e.key === 'Escape') {
     if (userDefModal.isOpen()) {
       e.stopPropagation();

--- a/js/frame-generator.js
+++ b/js/frame-generator.js
@@ -57,7 +57,12 @@ export function buildGridFrame({ storyHeights, spansX, spansY } = {}) {
     throw validationError(
       RangeError,
       `Grid frame member count ${memberCount} exceeds the limit of ${MAX_GRID_FRAME_MEMBERS}.`,
-      { reason: 'count', code: 'member-count' }
+      {
+        reason: 'count',
+        code: 'member-count',
+        count: memberCount,
+        max: MAX_GRID_FRAME_MEMBERS,
+      }
     );
   }
 
@@ -191,8 +196,6 @@ function configureLevels(state, storyHeights) {
     levels.push(state.addLevel(isRoof ? 'RF' : `${storyIndex + 2}F`, elevation));
   }
 
-  state.activeLevelId = groundLevel.id;
-  state.surfaceDraftTopLevelId = defaultUpperLevel.id;
   return levels;
 }
 

--- a/js/frame-generator.js
+++ b/js/frame-generator.js
@@ -1,0 +1,201 @@
+// frame-generator.js - DOM-independent grid-frame model generation.
+
+import { AppState } from './state.js';
+
+export const MIN_GRID_DIMENSION_MM = 1;
+export const MAX_GRID_DIMENSION_MM = 100_000;
+export const MAX_STORY_COUNT = 50;
+export const MAX_SPAN_COUNT = 100;
+export const MAX_GRID_FRAME_MEMBERS = 20_000;
+
+/**
+ * Parses a list of millimetre dimensions separated by commas, Japanese
+ * commas, or whitespace.
+ *
+ * @returns {{ ok: true, values: number[] } | { ok: false, reason: string }}
+ */
+export function parseMmList(text, { maxCount = MAX_SPAN_COUNT } = {}) {
+  if (typeof text !== 'string') return { ok: false, reason: 'invalid' };
+
+  const tokens = text.trim().split(/[,、\s]+/u).filter(Boolean);
+  if (tokens.length === 0) return { ok: false, reason: 'empty' };
+  if (tokens.length > maxCount) return { ok: false, reason: 'count' };
+
+  const values = [];
+  for (const token of tokens) {
+    const value = Number(token);
+    if (!Number.isFinite(value)) return { ok: false, reason: 'invalid' };
+    if (value < MIN_GRID_DIMENSION_MM || value > MAX_GRID_DIMENSION_MM) {
+      return { ok: false, reason: 'range' };
+    }
+    values.push(value);
+  }
+
+  return { ok: true, values };
+}
+
+/**
+ * Builds a fresh grid-frame model and returns its serialized JSON data.
+ * Input dimensions are millimetres.
+ */
+export function buildGridFrame({ storyHeights, spansX, spansY } = {}) {
+  const heights = validateMmValues(storyHeights, 'storyHeights', MAX_STORY_COUNT);
+  const xSpans = validateMmValues(spansX, 'spansX', MAX_SPAN_COUNT);
+  const ySpans = validateMmValues(spansY, 'spansY', MAX_SPAN_COUNT);
+
+  const storyCount = heights.length;
+  const xGridCount = xSpans.length + 1;
+  const yGridCount = ySpans.length + 1;
+  const columnCount = xGridCount * yGridCount * storyCount;
+  const beamCount = (
+    xSpans.length * yGridCount +
+    ySpans.length * xGridCount
+  ) * storyCount;
+  const memberCount = columnCount + beamCount;
+
+  if (memberCount > MAX_GRID_FRAME_MEMBERS) {
+    throw validationError(
+      RangeError,
+      `Grid frame member count ${memberCount} exceeds the limit of ${MAX_GRID_FRAME_MEMBERS}.`,
+      { reason: 'count', code: 'member-count' }
+    );
+  }
+
+  const xCoords = cumulativeCoordinates(xSpans);
+  const yCoords = cumulativeCoordinates(ySpans);
+  const state = new AppState();
+  state.meta.name = 'grid_frame';
+  state.meta.unit = 'mm';
+
+  const levels = configureLevels(state, heights);
+  const groundLevel = levels[0];
+  const planNodes = new Map();
+
+  xCoords.forEach((coord, index) => state.addAxis('x', `X${index + 1}`, coord));
+  yCoords.forEach((coord, index) => state.addAxis('y', `Y${index + 1}`, coord));
+
+  // A node stores plan coordinates; member level metadata supplies elevation.
+  // Keep one column node per grid point and story, matching the existing sample
+  // model convention. Beams below reuse one of those nodes via findNodeAt().
+  for (let storyIndex = 0; storyIndex < storyCount; storyIndex++) {
+    const bottomLevel = levels[storyIndex];
+    const topLevel = levels[storyIndex + 1];
+    for (const x of xCoords) {
+      for (const y of yCoords) {
+        const node = state.addNode(x, y);
+        if (storyIndex === 0) planNodes.set(planNodeKey(x, y), node);
+        state.addMember(node.id, node.id, {
+          type: 'column',
+          levelId: bottomLevel.id,
+          topLevelId: topLevel.id,
+        });
+        if (storyIndex === 0) {
+          state.addSupport(x, y, {
+            levelId: groundLevel.id,
+            dx: true,
+            dy: true,
+            dz: true,
+          });
+        }
+      }
+    }
+  }
+
+  const addBeam = (levelId, x1, y1, x2, y2) => {
+    let startNode = planNodes.get(planNodeKey(x1, y1)) || state.findNodeAt(x1, y1, 1);
+    if (!startNode) startNode = state.addNode(x1, y1);
+    let endNode = planNodes.get(planNodeKey(x2, y2)) || state.findNodeAt(x2, y2, 1);
+    if (!endNode) endNode = state.addNode(x2, y2);
+    state.addMember(startNode.id, endNode.id, { type: 'beam', levelId });
+  };
+
+  // Generate beams at every floor above GL, in both grid directions.
+  for (let levelIndex = 1; levelIndex < levels.length; levelIndex++) {
+    const levelId = levels[levelIndex].id;
+    for (const y of yCoords) {
+      for (let xIndex = 0; xIndex < xCoords.length - 1; xIndex++) {
+        addBeam(levelId, xCoords[xIndex], y, xCoords[xIndex + 1], y);
+      }
+    }
+    for (const x of xCoords) {
+      for (let yIndex = 0; yIndex < yCoords.length - 1; yIndex++) {
+        addBeam(levelId, x, yCoords[yIndex], x, yCoords[yIndex + 1]);
+      }
+    }
+  }
+
+  return state.toJSON();
+}
+
+function validateMmValues(values, field, maxCount) {
+  if (!Array.isArray(values) || values.length === 0) {
+    throw validationError(TypeError, `${field} must be a non-empty array.`, {
+      reason: 'invalid',
+      code: 'invalid-input',
+      field,
+    });
+  }
+  if (values.length > maxCount) {
+    throw validationError(RangeError, `${field} must contain at most ${maxCount} values.`, {
+      reason: 'count',
+      code: 'value-count',
+      field,
+    });
+  }
+
+  return values.map((value) => {
+    if (typeof value !== 'number' || !Number.isFinite(value)) {
+      throw validationError(TypeError, `${field} must contain only finite numbers.`, {
+        reason: 'invalid',
+        code: 'invalid-input',
+        field,
+      });
+    }
+    if (value < MIN_GRID_DIMENSION_MM || value > MAX_GRID_DIMENSION_MM) {
+      throw validationError(
+        RangeError,
+        `${field} values must be between ${MIN_GRID_DIMENSION_MM} and ${MAX_GRID_DIMENSION_MM} mm.`,
+        { reason: 'range', code: 'value-range', field }
+      );
+    }
+    return value;
+  });
+}
+
+function cumulativeCoordinates(spans) {
+  const coordinates = [0];
+  for (const span of spans) {
+    coordinates.push(coordinates[coordinates.length - 1] + span);
+  }
+  return coordinates;
+}
+
+function planNodeKey(x, y) {
+  return `${x}:${y}`;
+}
+
+function configureLevels(state, storyHeights) {
+  const [groundLevel, defaultUpperLevel] = [...state.levels].sort((a, b) => a.z - b.z);
+  const levels = [groundLevel, defaultUpperLevel];
+
+  state.updateLevel(groundLevel.id, { name: 'GL', z: 0 });
+  state.updateLevel(defaultUpperLevel.id, {
+    name: storyHeights.length === 1 ? 'RF' : '2F',
+    z: storyHeights[0],
+  });
+
+  let elevation = storyHeights[0];
+  for (let storyIndex = 1; storyIndex < storyHeights.length; storyIndex++) {
+    elevation += storyHeights[storyIndex];
+    const isRoof = storyIndex === storyHeights.length - 1;
+    levels.push(state.addLevel(isRoof ? 'RF' : `${storyIndex + 2}F`, elevation));
+  }
+
+  state.activeLevelId = groundLevel.id;
+  state.surfaceDraftTopLevelId = defaultUpperLevel.id;
+  return levels;
+}
+
+function validationError(ErrorType, message, details) {
+  return Object.assign(new ErrorType(message), details);
+}

--- a/js/grid-frame-modal.js
+++ b/js/grid-frame-modal.js
@@ -1,0 +1,204 @@
+// grid-frame-modal.js - Initial column/beam grid frame generation dialog.
+// Parsing and model construction stay DOM-independent in frame-generator.js;
+// this module owns only modal state and the whole-model replacement flow.
+
+import { buildGridFrame, parseMmList } from './frame-generator.js';
+import { t } from './i18n.js';
+import { showNotice } from './notice.js';
+
+const PARSE_ERROR_KEYS = {
+  empty: 'gridFrameEmptyInput',
+  invalid: 'gridFrameInvalidInput',
+  range: 'gridFrameOutOfRange',
+  count: 'gridFrameTooMany',
+};
+
+export function initGridFrameModal({
+  state,
+  history,
+  onModelChange,
+  syncSettingsControls,
+  refreshLevelSelectors,
+  hideSettingsModal = () => {},
+}) {
+  const modal = document.getElementById('grid-frame-modal');
+  const form = document.getElementById('grid-frame-form');
+  const settingsModal = document.getElementById('settings-modal');
+  let returnFocusElement = null;
+  const fields = [
+    {
+      key: 'storyHeights',
+      input: document.getElementById('grid-frame-story-heights'),
+      labelKey: 'gridFrameStoryHeights',
+      maxCount: 50,
+      initialValue: '',
+    },
+    {
+      key: 'spansX',
+      input: document.getElementById('grid-frame-spans-x'),
+      labelKey: 'gridFrameSpansX',
+      maxCount: 100,
+      initialValue: '',
+    },
+    {
+      key: 'spansY',
+      input: document.getElementById('grid-frame-spans-y'),
+      labelKey: 'gridFrameSpansY',
+      maxCount: 100,
+      initialValue: '',
+    },
+  ];
+  const retainedValues = Object.fromEntries(
+    fields.map(field => [field.key, field.initialValue])
+  );
+
+  function applyLanguage() {
+    modal.querySelectorAll('[data-i18n]').forEach(el => {
+      el.textContent = t(el.dataset.i18n);
+    });
+    modal.querySelectorAll('[data-i18n-placeholder]').forEach(el => {
+      el.placeholder = t(el.dataset.i18nPlaceholder);
+    });
+  }
+
+  function retainInputValues() {
+    for (const field of fields) retainedValues[field.key] = field.input.value;
+  }
+
+  function clearInputErrors() {
+    for (const field of fields) {
+      field.input.classList.remove('input-error');
+      field.input.removeAttribute('aria-invalid');
+    }
+  }
+
+  function show() {
+    returnFocusElement = document.activeElement instanceof HTMLElement
+      ? document.activeElement
+      : null;
+    applyLanguage();
+    clearInputErrors();
+    for (const field of fields) field.input.value = retainedValues[field.key];
+    settingsModal?.setAttribute('inert', '');
+    modal.classList.add('visible');
+    modal.setAttribute('aria-hidden', 'false');
+    requestAnimationFrame(() => fields[0].input.focus());
+  }
+
+  function hide({ restoreFocus = true } = {}) {
+    retainInputValues();
+    clearInputErrors();
+    modal.classList.remove('visible');
+    modal.setAttribute('aria-hidden', 'true');
+    settingsModal?.removeAttribute('inert');
+    if (restoreFocus && returnFocusElement?.isConnected) {
+      requestAnimationFrame(() => returnFocusElement.focus());
+    }
+  }
+
+  function parseInputs() {
+    clearInputErrors();
+    const parsed = {};
+    for (const field of fields) {
+      const result = parseMmList(field.input.value, { maxCount: field.maxCount });
+      if (!result.ok) {
+        field.input.classList.add('input-error');
+        field.input.setAttribute('aria-invalid', 'true');
+        field.input.focus();
+        const messageKey = PARSE_ERROR_KEYS[result.reason] || 'gridFrameInvalidInput';
+        showNotice(t(messageKey, { field: t(field.labelKey) }), 'error');
+        return null;
+      }
+      parsed[field.key] = result.values;
+    }
+    return parsed;
+  }
+
+  function errorMessage(error) {
+    if (error?.code === 'member-count') return t('gridFrameTooLarge');
+    return t('gridFrameGenerateFailed');
+  }
+
+  function generate() {
+    retainInputValues();
+    const values = parseInputs();
+    if (!values) return;
+
+    // Build against a fresh AppState before touching the current model or its
+    // history. Validation failures (including the member cap) must preserve an
+    // existing redo stack.
+    let generatedModel;
+    try {
+      generatedModel = buildGridFrame(values);
+    } catch (error) {
+      console.error('Grid frame generation failed:', error);
+      showNotice(errorMessage(error), 'error', 6500);
+      return;
+    }
+
+    const hasModelContent = state.nodes.length > 0 || state.members.length > 0;
+    if (hasModelContent && !window.confirm(t('gridFrameReplaceConfirm'))) return;
+
+    let snapshotSaved = false;
+    try {
+      history.save();
+      snapshotSaved = true;
+      state.loadJSON(generatedModel);
+      syncSettingsControls();
+      refreshLevelSelectors();
+      hide({ restoreFocus: false });
+      hideSettingsModal();
+      onModelChange();
+      requestAnimationFrame(() => document.getElementById('btn-settings')?.focus());
+
+      const columns = state.members.filter(member => member.type === 'column').length;
+      const beams = state.members.filter(member => member.type === 'beam').length;
+      showNotice(t('gridFrameDone', { columns, beams }), 'success');
+    } catch (error) {
+      console.error('Grid frame generation failed:', error);
+      if (snapshotSaved) history.undo();
+      syncSettingsControls();
+      refreshLevelSelectors();
+      onModelChange();
+      showNotice(errorMessage(error), 'error', 6500);
+    }
+  }
+
+  form.addEventListener('submit', event => {
+    event.preventDefault();
+    generate();
+  });
+  document.getElementById('btn-grid-frame-close').addEventListener('click', hide);
+  document.getElementById('btn-grid-frame-cancel').addEventListener('click', hide);
+  modal.addEventListener('click', event => {
+    if (event.target === modal) hide();
+  });
+  modal.addEventListener('keydown', event => {
+    if (event.key !== 'Tab') return;
+    const focusable = [...modal.querySelectorAll('button:not([disabled]), input:not([disabled])')]
+      .filter(element => !element.hidden);
+    if (!focusable.length) return;
+    const first = focusable[0];
+    const last = focusable[focusable.length - 1];
+    if (event.shiftKey && document.activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && document.activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  });
+  for (const field of fields) {
+    field.input.addEventListener('input', () => {
+      field.input.classList.remove('input-error');
+      field.input.removeAttribute('aria-invalid');
+    });
+  }
+
+  return {
+    show,
+    hide,
+    applyLanguage,
+    isOpen: () => modal.classList.contains('visible'),
+  };
+}

--- a/js/grid-frame-modal.js
+++ b/js/grid-frame-modal.js
@@ -2,7 +2,12 @@
 // Parsing and model construction stay DOM-independent in frame-generator.js;
 // this module owns only modal state and the whole-model replacement flow.
 
-import { buildGridFrame, parseMmList } from './frame-generator.js';
+import {
+  buildGridFrame,
+  MAX_SPAN_COUNT,
+  MAX_STORY_COUNT,
+  parseMmList,
+} from './frame-generator.js';
 import { t } from './i18n.js';
 import { showNotice } from './notice.js';
 
@@ -30,21 +35,21 @@ export function initGridFrameModal({
       key: 'storyHeights',
       input: document.getElementById('grid-frame-story-heights'),
       labelKey: 'gridFrameStoryHeights',
-      maxCount: 50,
+      maxCount: MAX_STORY_COUNT,
       initialValue: '',
     },
     {
       key: 'spansX',
       input: document.getElementById('grid-frame-spans-x'),
       labelKey: 'gridFrameSpansX',
-      maxCount: 100,
+      maxCount: MAX_SPAN_COUNT,
       initialValue: '',
     },
     {
       key: 'spansY',
       input: document.getElementById('grid-frame-spans-y'),
       labelKey: 'gridFrameSpansY',
-      maxCount: 100,
+      maxCount: MAX_SPAN_COUNT,
       initialValue: '',
     },
   ];
@@ -115,7 +120,9 @@ export function initGridFrameModal({
   }
 
   function errorMessage(error) {
-    if (error?.code === 'member-count') return t('gridFrameTooLarge');
+    if (error?.code === 'member-count') {
+      return t('gridFrameTooLarge', { count: error.count, max: error.max });
+    }
     return t('gridFrameGenerateFailed');
   }
 
@@ -157,6 +164,9 @@ export function initGridFrameModal({
     } catch (error) {
       console.error('Grid frame generation failed:', error);
       if (snapshotSaved) history.undo();
+      // The app-level History restore hook normally performs these updates.
+      // Keep an explicit fallback for callers without that hook and for a
+      // history.save()/undo() failure before a snapshot can be restored.
       syncSettingsControls();
       refreshLevelSelectors();
       onModelChange();

--- a/js/help-content.js
+++ b/js/help-content.js
@@ -16,6 +16,14 @@ export const helpContentJa = `
   <tr><td><b>削除</b></td><td>要素を選択してDeleteキー（複数選択にも対応）</td></tr>
 </table>
 
+<h3>初期モデル生成（格子フレーム）</h3>
+<ol>
+  <li>設定 →「初期モデル生成…」を開き、階高、X方向スパン、Y方向スパンを mm 単位で入力します。カンマ、読点、空白で複数の値を区切れます。</li>
+  <li>階高は下階から順に、スパンは原点から +X / +Y 方向へ順に指定します。例: 階高 <code>3500, 3000, 3000</code>、Xスパン <code>6000, 6000, 5000</code>。</li>
+  <li>「生成」で GL から RF までのレイヤー、X/Y通り芯、柱、梁、GLの並進3方向を拘束した支点を一括生成します。現在のモデルは置き換えられますが、「元に戻す」で復元できます。</li>
+</ol>
+<p>床・荷重・ブレースは生成されません。柱と梁は既定の断面で生成されるため、生成後に必要な断面へ変更してください。</p>
+
 <h3>通り芯・下絵・軸組図</h3>
 <table>
   <tr><td><b>通り芯</b></td><td>ツールバーの「通り芯管理」でX/Y通りの名前と座標を定義。2Dに一点鎖線で表示され、交点にスナップします</td></tr>
@@ -140,6 +148,14 @@ export const helpContentEn = `
   <tr><td><b>Move</b></td><td>After selecting, drag a node or line element (the whole group moves during multi-selection). Or edit start/end X,Y coordinates in the property panel</td></tr>
   <tr><td><b>Delete</b></td><td>Select element(s) and press Delete key</td></tr>
 </table>
+
+<h3>Initial Model Generation (Grid Frame)</h3>
+<ol>
+  <li>Open Settings → "Generate Initial Model…", then enter story heights, X-direction spans, and Y-direction spans in millimetres. Separate multiple values with commas, Japanese commas, or spaces.</li>
+  <li>List story heights from the bottom story upward, and spans from the origin in the +X / +Y directions. Example: story heights <code>3500, 3000, 3000</code>; X spans <code>6000, 6000, 5000</code>.</li>
+  <li>Click "Generate" to create layers from GL through RF, X/Y grid axes, columns, beams, and supports restrained in DX/DY/DZ at GL. This replaces the current model; use Undo to restore it.</li>
+</ol>
+<p>Floors, loads, and braces are not generated. Columns and beams use the default sections, which you can change after generation.</p>
 
 <h3>Grid Axes, Underlay &amp; Elevation</h3>
 <table>

--- a/js/history.js
+++ b/js/history.js
@@ -7,6 +7,11 @@ export class History {
     this.state = state;
     this.undoStack = [];
     this.redoStack = [];
+    this.onRestore = null;
+  }
+
+  setOnRestore(callback) {
+    this.onRestore = typeof callback === 'function' ? callback : null;
   }
 
   save() {
@@ -38,6 +43,7 @@ export class History {
     this.redoStack.push(this.state.snapshot());
     const snap = this.undoStack.pop();
     this.state.restoreSnapshot(snap);
+    this.onRestore?.();
     return true;
   }
 
@@ -46,6 +52,7 @@ export class History {
     this.undoStack.push(this.state.snapshot());
     const snap = this.redoStack.pop();
     this.state.restoreSnapshot(snap);
+    this.onRestore?.();
     return true;
   }
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -416,6 +416,25 @@ const dict = {
     sampleFrame: '2階建フレーム',
     sampleLoaded: 'サンプルモデルを読み込みました。',
     sampleLoadFailed: 'サンプルモデルの読み込みに失敗しました。',
+
+    // Initial grid frame
+    gridFrameOpen: '初期モデル生成…',
+    gridFrameTitle: '初期モデル生成（格子フレーム）',
+    gridFrameStoryHeights: '階高リスト',
+    gridFrameSpansX: 'X方向スパンリスト',
+    gridFrameSpansY: 'Y方向スパンリスト',
+    gridFrameStoryHeightsPlaceholder: '例: 3500, 3000, 3000',
+    gridFrameSpansXPlaceholder: '例: 6000, 6000, 5000',
+    gridFrameSpansYPlaceholder: '例: 6000, 6000',
+    gridFrameGenerate: '生成',
+    gridFrameReplaceConfirm: '現在のモデルを格子フレームで置き換えます。元のモデルは「元に戻す」で復元できます。続行しますか？',
+    gridFrameDone: '格子フレームを生成しました（柱 {columns}本・梁 {beams}本）。',
+    gridFrameEmptyInput: '{field}を入力してください。',
+    gridFrameInvalidInput: '{field}は正の数値をカンマ、読点または空白で区切って入力してください。',
+    gridFrameOutOfRange: '{field}の各値は1〜100,000 mmの範囲で入力してください。',
+    gridFrameTooMany: '{field}の入力個数が上限を超えています。',
+    gridFrameTooLarge: '生成される部材数が上限を超えます。階数またはスパン数を減らしてください。',
+    gridFrameGenerateFailed: '格子フレームの生成に失敗しました。',
   },
 
   en: {
@@ -833,6 +852,25 @@ const dict = {
     sampleFrame: 'Two-story frame',
     sampleLoaded: 'Sample model loaded.',
     sampleLoadFailed: 'Failed to load sample model.',
+
+    // Initial grid frame
+    gridFrameOpen: 'Generate Initial Model…',
+    gridFrameTitle: 'Generate Initial Grid Frame',
+    gridFrameStoryHeights: 'Story height list',
+    gridFrameSpansX: 'X-direction span list',
+    gridFrameSpansY: 'Y-direction span list',
+    gridFrameStoryHeightsPlaceholder: 'e.g. 3500, 3000, 3000',
+    gridFrameSpansXPlaceholder: 'e.g. 6000, 6000, 5000',
+    gridFrameSpansYPlaceholder: 'e.g. 6000, 6000',
+    gridFrameGenerate: 'Generate',
+    gridFrameReplaceConfirm: 'Replace the current model with the grid frame? You can restore the previous model with Undo.',
+    gridFrameDone: 'Grid frame generated (columns: {columns}, beams: {beams}).',
+    gridFrameEmptyInput: 'Enter {field}.',
+    gridFrameInvalidInput: 'Enter {field} as positive numbers separated by commas, Japanese commas, or spaces.',
+    gridFrameOutOfRange: 'Each value in {field} must be between 1 and 100,000 mm.',
+    gridFrameTooMany: '{field} contains more values than allowed.',
+    gridFrameTooLarge: 'The generated model would exceed the member limit. Reduce the number of stories or spans.',
+    gridFrameGenerateFailed: 'Failed to generate the grid frame.',
   },
 };
 

--- a/js/i18n.js
+++ b/js/i18n.js
@@ -433,7 +433,7 @@ const dict = {
     gridFrameInvalidInput: '{field}は正の数値をカンマ、読点または空白で区切って入力してください。',
     gridFrameOutOfRange: '{field}の各値は1〜100,000 mmの範囲で入力してください。',
     gridFrameTooMany: '{field}の入力個数が上限を超えています。',
-    gridFrameTooLarge: '生成される部材数が上限を超えます。階数またはスパン数を減らしてください。',
+    gridFrameTooLarge: '生成される部材数（{count}）が上限（{max}）を超えます。階数またはスパン数を減らしてください。',
     gridFrameGenerateFailed: '格子フレームの生成に失敗しました。',
   },
 
@@ -869,7 +869,7 @@ const dict = {
     gridFrameInvalidInput: 'Enter {field} as positive numbers separated by commas, Japanese commas, or spaces.',
     gridFrameOutOfRange: 'Each value in {field} must be between 1 and 100,000 mm.',
     gridFrameTooMany: '{field} contains more values than allowed.',
-    gridFrameTooLarge: 'The generated model would exceed the member limit. Reduce the number of stories or spans.',
+    gridFrameTooLarge: 'The generated member count ({count}) exceeds the limit ({max}). Reduce the number of stories or spans.',
     gridFrameGenerateFailed: 'Failed to generate the grid frame.',
   },
 };

--- a/js/notice.js
+++ b/js/notice.js
@@ -21,6 +21,8 @@ export function showNotice(message, kind = 'error', durationMs = 4200) {
 
   const notice = document.createElement('div');
   notice.className = `app-notice app-notice-${kind}`;
+  notice.setAttribute('role', kind === 'error' ? 'alert' : 'status');
+  notice.setAttribute('aria-live', kind === 'error' ? 'assertive' : 'polite');
   notice.textContent = text;
   host.appendChild(notice);
 

--- a/js/tools.js
+++ b/js/tools.js
@@ -295,7 +295,11 @@ export class ToolManager {
   }
 
   _onKeyDown(e) {
-    if (e.code === 'Space') {
+    const targetTag = e.target?.tagName;
+    const isEditableTarget = targetTag === 'INPUT' || targetTag === 'SELECT' ||
+      targetTag === 'TEXTAREA' || e.target?.isContentEditable;
+
+    if (e.code === 'Space' && !isEditableTarget) {
       this._spaceDown = true;
       e.preventDefault();
     }
@@ -325,8 +329,7 @@ export class ToolManager {
     }
 
     // Delete (skip when focused on input/select)
-    if ((e.key === 'Delete' || e.key === 'Backspace') &&
-        e.target.tagName !== 'INPUT' && e.target.tagName !== 'SELECT' && e.target.tagName !== 'TEXTAREA') {
+    if ((e.key === 'Delete' || e.key === 'Backspace') && !isEditableTarget) {
       if (this.state.selectedSupportId) {
         const support = this.state.getSupport(this.state.selectedSupportId);
         if (!this.state.isSupportSelectable(support)) return;
@@ -359,7 +362,7 @@ export class ToolManager {
     }
 
     // Undo/Redo
-    if (e.ctrlKey || e.metaKey) {
+    if ((e.ctrlKey || e.metaKey) && !isEditableTarget) {
       if (e.key === 'z' && !e.shiftKey) {
         e.preventDefault();
         if (this.history.undo()) this.onUpdate();
@@ -370,7 +373,8 @@ export class ToolManager {
     }
 
     // Close polyline surface
-    if (this.state.currentTool === 'surface' && this.state.surfaceDraftMode === 'polyline' &&
+    if (!isEditableTarget && this.state.currentTool === 'surface' &&
+        this.state.surfaceDraftMode === 'polyline' &&
         (e.key === 'Enter' || e.key === 'Return')) {
       this._finishSurfacePolyline();
     }

--- a/test/frame-generator.test.js
+++ b/test/frame-generator.test.js
@@ -254,6 +254,10 @@ test('buildGridFrame revalidates input counts, values, and total member cap', ()
   assert.ok(projectedMembers > MAX_GRID_FRAME_MEMBERS);
   assert.throws(
     () => buildGridFrame(oversized),
-    error => error instanceof RangeError && error.reason === 'count' && error.code === 'member-count'
+    error => error instanceof RangeError &&
+      error.reason === 'count' &&
+      error.code === 'member-count' &&
+      error.count === projectedMembers &&
+      error.max === MAX_GRID_FRAME_MEMBERS
   );
 });

--- a/test/frame-generator.test.js
+++ b/test/frame-generator.test.js
@@ -1,0 +1,259 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+
+import {
+  buildGridFrame,
+  MAX_GRID_FRAME_MEMBERS,
+  parseMmList,
+} from '../js/frame-generator.js';
+import { buildAnalysisModel } from '../js/analysis-export.js';
+import { AppState } from '../js/state.js';
+
+function loadGridFrame(input) {
+  const data = buildGridFrame(input);
+  const state = new AppState();
+  state.loadJSON(data);
+  return { data, state };
+}
+
+test('parseMmList accepts comma, Japanese comma, whitespace, and decimal values', () => {
+  assert.deepEqual(parseMmList('3500, 3000、2750.5\n2500'), {
+    ok: true,
+    values: [3500, 3000, 2750.5, 2500],
+  });
+  assert.deepEqual(parseMmList('  6000  \t 5000  '), {
+    ok: true,
+    values: [6000, 5000],
+  });
+  assert.deepEqual(parseMmList('6000,,、 5000'), {
+    ok: true,
+    values: [6000, 5000],
+  });
+});
+
+test('parseMmList classifies empty, invalid, range, and count errors', () => {
+  assert.deepEqual(parseMmList('  , 、 \n '), { ok: false, reason: 'empty' });
+  assert.deepEqual(parseMmList('3000, nope'), { ok: false, reason: 'invalid' });
+  assert.deepEqual(parseMmList('Infinity'), { ok: false, reason: 'invalid' });
+  assert.deepEqual(parseMmList(null), { ok: false, reason: 'invalid' });
+
+  for (const value of ['-1', '0', '0.5', '100000.1']) {
+    assert.deepEqual(parseMmList(value), { ok: false, reason: 'range' }, value);
+  }
+  assert.deepEqual(parseMmList('1'), { ok: true, values: [1] });
+  assert.deepEqual(parseMmList('100000'), { ok: true, values: [100000] });
+
+  assert.deepEqual(parseMmList('1000,1000,1000', { maxCount: 2 }), {
+    ok: false,
+    reason: 'count',
+  });
+  assert.equal(
+    parseMmList(Array.from({ length: 101 }, () => '1000').join(',')).reason,
+    'count'
+  );
+});
+
+test('buildGridFrame creates the expected 3-story, 3-by-2-span model', () => {
+  const { state } = loadGridFrame({
+    storyHeights: [3500, 3000, 3000],
+    spansX: [6000, 6000, 5000],
+    spansY: [6000, 6000],
+  });
+
+  assert.equal(state.meta.name, 'grid_frame');
+  assert.equal(state.meta.unit, 'mm');
+  assert.deepEqual(
+    [...state.levels].sort((a, b) => a.z - b.z).map(({ name, z }) => ({ name, z })),
+    [
+      { name: 'GL', z: 0 },
+      { name: '2F', z: 3500 },
+      { name: '3F', z: 6500 },
+      { name: 'RF', z: 9500 },
+    ]
+  );
+  assert.deepEqual(
+    state.axes.filter(axis => axis.dir === 'x').map(({ name, coord }) => ({ name, coord })),
+    [
+      { name: 'X1', coord: 0 },
+      { name: 'X2', coord: 6000 },
+      { name: 'X3', coord: 12000 },
+      { name: 'X4', coord: 17000 },
+    ]
+  );
+  assert.deepEqual(
+    state.axes.filter(axis => axis.dir === 'y').map(({ name, coord }) => ({ name, coord })),
+    [
+      { name: 'Y1', coord: 0 },
+      { name: 'Y2', coord: 6000 },
+      { name: 'Y3', coord: 12000 },
+    ]
+  );
+
+  const columns = state.members.filter(member => member.type === 'column');
+  const beams = state.members.filter(member => member.type === 'beam');
+  assert.equal(state.levels.length, 4);
+  assert.equal(state.axes.length, 7);
+  assert.equal(columns.length, (3 + 1) * (2 + 1) * 3);
+  assert.equal(beams.length, (3 * (2 + 1) + 2 * (3 + 1)) * 3);
+  const beamsPerFloor = 3 * (2 + 1) + 2 * (3 + 1);
+  const sortedLevels = [...state.levels].sort((a, b) => a.z - b.z);
+  assert.equal(beams.filter(beam => beam.levelId === sortedLevels[0].id).length, 0);
+  for (const level of sortedLevels.slice(1)) {
+    assert.equal(
+      beams.filter(beam => beam.levelId === level.id).length,
+      beamsPerFloor,
+      `${level.name}: expected beam count`
+    );
+  }
+  assert.equal(state.supports.length, (3 + 1) * (2 + 1));
+  assert.equal(state.nodes.length, columns.length, 'beam generation adds no duplicate nodes');
+  assert.deepEqual(state.surfaces, []);
+  assert.deepEqual(state.loads, []);
+});
+
+test('buildGridFrame creates and validates the minimum 1-story, 1-by-1-span model', () => {
+  const { state } = loadGridFrame({
+    storyHeights: [2800],
+    spansX: [4000],
+    spansY: [5000],
+  });
+
+  assert.deepEqual(state.levels.map(level => level.name), ['GL', 'RF']);
+  assert.deepEqual(state.levels.map(level => level.z), [0, 2800]);
+  assert.equal(state.members.filter(member => member.type === 'column').length, 4);
+  assert.equal(state.members.filter(member => member.type === 'beam').length, 4);
+  assert.equal(state.nodes.length, 4);
+  assert.equal(state.supports.length, 4);
+  assert.deepEqual(
+    state.validateModel().filter(issue => issue.severity === 'error'),
+    []
+  );
+});
+
+test('generated member connectivity reuses column nodes and follows adjacent grid lines', () => {
+  const { state } = loadGridFrame({
+    storyHeights: [3500, 3000],
+    spansX: [6000, 5000],
+    spansY: [4500],
+  });
+  const nodeIds = new Set(state.nodes.map(node => node.id));
+  const columns = state.members.filter(member => member.type === 'column');
+  const beams = state.members.filter(member => member.type === 'beam');
+  const columnNodeIds = new Set(columns.map(member => member.startNodeId));
+  const levelById = new Map(state.levels.map(level => [level.id, level]));
+
+  for (const member of state.members) {
+    assert.ok(nodeIds.has(member.startNodeId), `${member.id}: start node exists`);
+    assert.ok(nodeIds.has(member.endNodeId), `${member.id}: end node exists`);
+  }
+  for (const column of columns) {
+    assert.equal(column.startNodeId, column.endNodeId);
+    assert.ok(levelById.get(column.topLevelId).z > levelById.get(column.levelId).z);
+  }
+  for (const beam of beams) {
+    assert.notEqual(beam.startNodeId, beam.endNodeId);
+    assert.ok(columnNodeIds.has(beam.startNodeId), `${beam.id}: reuses start column node`);
+    assert.ok(columnNodeIds.has(beam.endNodeId), `${beam.id}: reuses end column node`);
+    const start = state.getNode(beam.startNodeId);
+    const end = state.getNode(beam.endNodeId);
+    const changesX = start.x !== end.x && start.y === end.y;
+    const changesY = start.x === end.x && start.y !== end.y;
+    assert.ok(changesX !== changesY, `${beam.id}: follows exactly one grid direction`);
+  }
+
+  const errors = state.validateModel().filter(issue => issue.severity === 'error');
+  assert.deepEqual(errors, []);
+
+  const analysis = buildAnalysisModel(state);
+  const analysisNodeById = new Map(analysis.nodes.map(node => [node.id, node]));
+  for (const element of analysis.elements.filter(item => item.type === 'beam')) {
+    const expectedZ = levelById.get(element.levelId).z;
+    assert.equal(analysisNodeById.get(element.nodeI).z, expectedZ, `${element.id}: node I z`);
+    assert.equal(analysisNodeById.get(element.nodeJ).z, expectedZ, `${element.id}: node J z`);
+  }
+});
+
+test('generated supports fix translation at every GL grid intersection', () => {
+  const { state } = loadGridFrame({
+    storyHeights: [3000, 3000],
+    spansX: [4000, 5000],
+    spansY: [6000],
+  });
+  const groundLevel = state.levels.find(level => level.name === 'GL');
+  const expectedPoints = new Set([
+    '0,0', '0,6000',
+    '4000,0', '4000,6000',
+    '9000,0', '9000,6000',
+  ]);
+
+  assert.equal(state.supports.length, expectedPoints.size);
+  for (const support of state.supports) {
+    assert.ok(expectedPoints.delete(`${support.x},${support.y}`));
+    assert.equal(support.levelId, groundLevel.id);
+    assert.equal(support.dx, true);
+    assert.equal(support.dy, true);
+    assert.equal(support.dz, true);
+    assert.equal(support.rx, false);
+    assert.equal(support.ry, false);
+    assert.equal(support.rz, false);
+  }
+  assert.equal(expectedPoints.size, 0);
+});
+
+test('generated JSON survives an AppState load and serialize round trip', () => {
+  const input = {
+    storyHeights: [3200, 2800],
+    spansX: [4500, 5500],
+    spansY: [4000, 4000],
+  };
+  const data = buildGridFrame(input);
+  const restored = new AppState();
+
+  assert.doesNotThrow(() => restored.loadJSON(data));
+  assert.deepEqual(restored.toJSON(), data);
+  assert.deepEqual(
+    restored.validateModel().filter(issue => issue.severity === 'error'),
+    []
+  );
+});
+
+test('buildGridFrame revalidates input counts, values, and total member cap', () => {
+  const valid = {
+    storyHeights: [3000],
+    spansX: [6000],
+    spansY: [6000],
+  };
+
+  assert.throws(
+    () => buildGridFrame({ ...valid, storyHeights: [] }),
+    error => error instanceof TypeError && error.code === 'invalid-input'
+  );
+  assert.throws(
+    () => buildGridFrame({ ...valid, storyHeights: ['3000'] }),
+    error => error instanceof TypeError && error.code === 'invalid-input'
+  );
+  assert.throws(
+    () => buildGridFrame({ ...valid, spansX: [0] }),
+    error => error instanceof RangeError && error.code === 'value-range'
+  );
+  assert.throws(
+    () => buildGridFrame({ ...valid, storyHeights: Array(51).fill(3000) }),
+    error => error instanceof RangeError && error.code === 'value-count' && error.field === 'storyHeights'
+  );
+  assert.throws(
+    () => buildGridFrame({ ...valid, spansY: Array(101).fill(6000) }),
+    error => error instanceof RangeError && error.code === 'value-count' && error.field === 'spansY'
+  );
+
+  const oversized = {
+    storyHeights: Array(50).fill(3000),
+    spansX: Array(12).fill(6000),
+    spansY: Array(12).fill(6000),
+  };
+  const projectedMembers = 50 * ((13 * 13) + (12 * 13) + (12 * 13));
+  assert.ok(projectedMembers > MAX_GRID_FRAME_MEMBERS);
+  assert.throws(
+    () => buildGridFrame(oversized),
+    error => error instanceof RangeError && error.reason === 'count' && error.code === 'member-count'
+  );
+});

--- a/test/grid-frame-ui.test.js
+++ b/test/grid-frame-ui.test.js
@@ -2,7 +2,212 @@ import test from 'node:test';
 import assert from 'node:assert/strict';
 import { readFile } from 'node:fs/promises';
 
+import { MAX_GRID_FRAME_MEMBERS } from '../js/frame-generator.js';
+import { initGridFrameModal } from '../js/grid-frame-modal.js';
+import { AppState } from '../js/state.js';
 import { ToolManager } from '../js/tools.js';
+
+class FakeClassList {
+  constructor() {
+    this.values = new Set();
+  }
+
+  add(value) {
+    this.values.add(value);
+  }
+
+  remove(value) {
+    this.values.delete(value);
+  }
+
+  contains(value) {
+    return this.values.has(value);
+  }
+}
+
+class FakeElement extends EventTarget {
+  constructor(ownerDocument, id = '', tagName = 'DIV') {
+    super();
+    this.ownerDocument = ownerDocument;
+    this.id = id;
+    this.tagName = tagName;
+    this.classList = new FakeClassList();
+    this.dataset = {};
+    this.children = [];
+    this.attributes = new Map();
+    this.textContent = '';
+    this.value = '';
+    this.placeholder = '';
+    this.hidden = false;
+    this.isConnected = true;
+    this.parentElement = null;
+    this._innerHTML = '';
+  }
+
+  appendChild(child) {
+    child.parentElement = this;
+    this.children.push(child);
+    if (child.id) this.ownerDocument.elements.set(child.id, child);
+    return child;
+  }
+
+  remove() {
+    if (this.parentElement) {
+      this.parentElement.children = this.parentElement.children.filter(child => child !== this);
+    }
+    this.isConnected = false;
+  }
+
+  set innerHTML(value) {
+    this._innerHTML = String(value);
+    if (value === '') this.children = [];
+  }
+
+  get innerHTML() {
+    return this._innerHTML;
+  }
+
+  setAttribute(name, value) {
+    this.attributes.set(name, String(value));
+  }
+
+  getAttribute(name) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  removeAttribute(name) {
+    this.attributes.delete(name);
+  }
+
+  querySelectorAll(selector) {
+    return this.ownerDocument.queries.get(`${this.id}:${selector}`) || [];
+  }
+
+  focus() {
+    this.ownerDocument.activeElement = this;
+  }
+}
+
+function createFakeDocument() {
+  const root = {
+    elements: new Map(),
+    queries: new Map(),
+    activeElement: null,
+    documentElement: {},
+    getElementById(id) {
+      return root.elements.get(id) || null;
+    },
+    createElement(tagName) {
+      return new FakeElement(root, '', tagName.toUpperCase());
+    },
+  };
+  root.body = new FakeElement(root, 'body', 'BODY');
+
+  const elementTypes = {
+    'grid-frame-form': 'FORM',
+    'grid-frame-story-heights': 'INPUT',
+    'grid-frame-spans-x': 'INPUT',
+    'grid-frame-spans-y': 'INPUT',
+    'btn-grid-frame-close': 'BUTTON',
+    'btn-grid-frame-cancel': 'BUTTON',
+    'btn-grid-frame-generate': 'BUTTON',
+    'btn-grid-frame': 'BUTTON',
+    'btn-settings': 'BUTTON',
+  };
+  for (const id of [
+    'grid-frame-modal',
+    'grid-frame-form',
+    'grid-frame-story-heights',
+    'grid-frame-spans-x',
+    'grid-frame-spans-y',
+    'btn-grid-frame-close',
+    'btn-grid-frame-cancel',
+    'btn-grid-frame-generate',
+    'btn-grid-frame',
+    'btn-settings',
+    'settings-modal',
+    'app-notice-host',
+  ]) {
+    root.elements.set(id, new FakeElement(root, id, elementTypes[id] || 'DIV'));
+  }
+
+  const modal = root.getElementById('grid-frame-modal');
+  const inputs = [
+    root.getElementById('grid-frame-story-heights'),
+    root.getElementById('grid-frame-spans-x'),
+    root.getElementById('grid-frame-spans-y'),
+  ];
+  inputs[0].dataset.i18nPlaceholder = 'gridFrameStoryHeightsPlaceholder';
+  inputs[1].dataset.i18nPlaceholder = 'gridFrameSpansXPlaceholder';
+  inputs[2].dataset.i18nPlaceholder = 'gridFrameSpansYPlaceholder';
+  const localized = [
+    root.getElementById('btn-grid-frame-close'),
+    root.getElementById('btn-grid-frame-cancel'),
+    root.getElementById('btn-grid-frame-generate'),
+  ];
+  localized[0].dataset.i18n = 'helpClose';
+  localized[1].dataset.i18n = 'choiceCancel';
+  localized[2].dataset.i18n = 'gridFrameGenerate';
+  root.queries.set('grid-frame-modal:[data-i18n]', localized);
+  root.queries.set('grid-frame-modal:[data-i18n-placeholder]', inputs);
+  root.queries.set('grid-frame-modal:button:not([disabled]), input:not([disabled])', [
+    localized[0],
+    ...inputs,
+    localized[1],
+    localized[2],
+  ]);
+  root.body.appendChild(root.getElementById('app-notice-host'));
+  root.activeElement = root.getElementById('btn-grid-frame');
+
+  let nextTimerId = 1;
+  root.defaultView = {
+    confirm: () => true,
+    setTimeout: () => nextTimerId++,
+    clearTimeout: () => {},
+  };
+  return root;
+}
+
+async function withFakeBrowser(callback) {
+  const originals = {
+    document: globalThis.document,
+    window: globalThis.window,
+    HTMLElement: globalThis.HTMLElement,
+    requestAnimationFrame: globalThis.requestAnimationFrame,
+  };
+  const root = createFakeDocument();
+  globalThis.document = root;
+  globalThis.window = root.defaultView;
+  globalThis.HTMLElement = FakeElement;
+  globalThis.requestAnimationFrame = callback => {
+    callback();
+    return 1;
+  };
+  try {
+    return await callback(root);
+  } finally {
+    for (const [name, value] of Object.entries(originals)) {
+      if (value === undefined) delete globalThis[name];
+      else globalThis[name] = value;
+    }
+  }
+}
+
+function setValidInputs(root, storyHeights = '2800') {
+  root.getElementById('grid-frame-story-heights').value = storyHeights;
+  root.getElementById('grid-frame-spans-x').value = '4000';
+  root.getElementById('grid-frame-spans-y').value = '5000';
+}
+
+function latestNotice(root) {
+  return root.getElementById('app-notice-host').children.at(-1);
+}
+
+function dispatchSubmit(root) {
+  const event = new Event('submit', { cancelable: true });
+  root.getElementById('grid-frame-form').dispatchEvent(event);
+  assert.equal(event.defaultPrevented, true);
+}
 
 test('initial grid frame modal exposes all inputs and actions', async () => {
   const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
@@ -26,38 +231,186 @@ test('initial grid frame modal exposes all inputs and actions', async () => {
   assert.match(html, /data-i18n-placeholder="gridFrameSpansYPlaceholder"/);
 });
 
-test('grid frame modal wires validation, replacement, and rollback flow', async () => {
-  const source = await readFile(new URL('../js/grid-frame-modal.js', import.meta.url), 'utf8');
+test('grid frame modal retains input and restores focus after cancellation', () =>
+  withFakeBrowser(root => {
+    const controller = initGridFrameModal({
+      state: { nodes: [], members: [] },
+      history: { save() {}, undo() {} },
+      onModelChange() {},
+      syncSettingsControls() {},
+      refreshLevelSelectors() {},
+    });
 
-  assert.match(source, /parseMmList\(field\.input\.value, \{ maxCount: field\.maxCount \}\)/);
-  assert.match(source, /state\.nodes\.length > 0 \|\| state\.members\.length > 0/);
-  assert.match(source, /window\.confirm\(t\('gridFrameReplaceConfirm'\)\)/);
-  assert.match(source, /generatedModel = buildGridFrame\(values\)/);
-  assert.match(source, /history\.save\(\)/);
-  assert.match(source, /state\.loadJSON\(generatedModel\)/);
-  assert.match(source, /syncSettingsControls\(\)/);
-  assert.match(source, /refreshLevelSelectors\(\)/);
-  assert.match(source, /history\.undo\(\)/);
-  assert.match(source, /gridFrameDone/);
-  assert.match(source, /gridFrameTooLarge/);
+    controller.show();
+    setValidInputs(root, '2800 3000');
+    root.getElementById('btn-grid-frame-cancel').dispatchEvent(new Event('click'));
 
-  assert.ok(
-    source.indexOf('generatedModel = buildGridFrame(values)') < source.indexOf('history.save()'),
-    'validation/build must finish before history.save() clears redo'
-  );
-});
+    assert.equal(controller.isOpen(), false);
+    assert.equal(root.getElementById('settings-modal').getAttribute('inert'), null);
+    assert.equal(root.activeElement, root.getElementById('btn-grid-frame'));
 
-test('app wires the grid frame modal and Escape handling', async () => {
+    controller.show();
+    assert.equal(root.getElementById('grid-frame-story-heights').value, '2800 3000');
+    assert.equal(root.getElementById('grid-frame-spans-x').value, '4000');
+    assert.equal(root.getElementById('grid-frame-spans-y').value, '5000');
+  })
+);
+
+test('grid frame modal keeps invalid input open and does not touch history', () =>
+  withFakeBrowser(root => {
+    let saveCalls = 0;
+    let loadCalls = 0;
+    const controller = initGridFrameModal({
+      state: { nodes: [], members: [], loadJSON() { loadCalls++; } },
+      history: { save() { saveCalls++; }, undo() {} },
+      onModelChange() {},
+      syncSettingsControls() {},
+      refreshLevelSelectors() {},
+    });
+
+    controller.show();
+    setValidInputs(root, '0');
+    dispatchSubmit(root);
+
+    const input = root.getElementById('grid-frame-story-heights');
+    assert.equal(controller.isOpen(), true);
+    assert.equal(input.getAttribute('aria-invalid'), 'true');
+    assert.equal(root.activeElement, input);
+    assert.equal(saveCalls, 0);
+    assert.equal(loadCalls, 0);
+    assert.match(latestNotice(root).textContent, /1〜100,000 mm/);
+  })
+);
+
+test('grid frame modal respects replacement cancellation', () =>
+  withFakeBrowser(root => {
+    let confirmCalls = 0;
+    let saveCalls = 0;
+    let loadCalls = 0;
+    root.defaultView.confirm = () => {
+      confirmCalls++;
+      return false;
+    };
+    const controller = initGridFrameModal({
+      state: { nodes: [{ id: 1 }], members: [], loadJSON() { loadCalls++; } },
+      history: { save() { saveCalls++; }, undo() {} },
+      onModelChange() {},
+      syncSettingsControls() {},
+      refreshLevelSelectors() {},
+    });
+
+    controller.show();
+    setValidInputs(root);
+    dispatchSubmit(root);
+
+    assert.equal(confirmCalls, 1);
+    assert.equal(saveCalls, 0);
+    assert.equal(loadCalls, 0);
+    assert.equal(controller.isOpen(), true);
+  })
+);
+
+test('grid frame modal replaces the model and synchronizes the UI', () =>
+  withFakeBrowser(root => {
+    const state = new AppState();
+    const calls = { save: 0, sync: 0, refresh: 0, change: 0, hideSettings: 0 };
+    const controller = initGridFrameModal({
+      state,
+      history: { save() { calls.save++; }, undo() { return true; } },
+      onModelChange() { calls.change++; },
+      syncSettingsControls() { calls.sync++; },
+      refreshLevelSelectors() { calls.refresh++; },
+      hideSettingsModal() { calls.hideSettings++; },
+    });
+
+    controller.show();
+    setValidInputs(root);
+    dispatchSubmit(root);
+
+    assert.deepEqual(calls, { save: 1, sync: 1, refresh: 1, change: 1, hideSettings: 1 });
+    assert.equal(state.members.filter(member => member.type === 'column').length, 4);
+    assert.equal(state.members.filter(member => member.type === 'beam').length, 4);
+    assert.equal(controller.isOpen(), false);
+    assert.equal(root.activeElement, root.getElementById('btn-settings'));
+    assert.match(latestNotice(root).textContent, /柱 4本・梁 4本/);
+    assert.equal(latestNotice(root).getAttribute('role'), 'status');
+  })
+);
+
+test('grid frame modal reports projected and maximum member counts before saving', () =>
+  withFakeBrowser(root => {
+    let saveCalls = 0;
+    const controller = initGridFrameModal({
+      state: { nodes: [], members: [] },
+      history: { save() { saveCalls++; }, undo() {} },
+      onModelChange() {},
+      syncSettingsControls() {},
+      refreshLevelSelectors() {},
+    });
+    const stories = Array(50).fill('3000').join(',');
+    const spans = Array(12).fill('6000').join(',');
+    const projectedMembers = 50 * ((13 * 13) + (12 * 13) + (12 * 13));
+
+    controller.show();
+    setValidInputs(root, stories);
+    root.getElementById('grid-frame-spans-x').value = spans;
+    root.getElementById('grid-frame-spans-y').value = spans;
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    try {
+      dispatchSubmit(root);
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    assert.equal(saveCalls, 0);
+    assert.equal(controller.isOpen(), true);
+    assert.match(latestNotice(root).textContent, new RegExp(String(projectedMembers)));
+    assert.match(latestNotice(root).textContent, new RegExp(String(MAX_GRID_FRAME_MEMBERS)));
+  })
+);
+
+test('grid frame modal rolls back and resynchronizes after a load failure', () =>
+  withFakeBrowser(root => {
+    const calls = { save: 0, undo: 0, sync: 0, refresh: 0, change: 0 };
+    const controller = initGridFrameModal({
+      state: {
+        nodes: [],
+        members: [],
+        loadJSON() { throw new Error('load failed'); },
+      },
+      history: {
+        save() { calls.save++; },
+        undo() { calls.undo++; return true; },
+      },
+      onModelChange() { calls.change++; },
+      syncSettingsControls() { calls.sync++; },
+      refreshLevelSelectors() { calls.refresh++; },
+    });
+
+    controller.show();
+    setValidInputs(root);
+    const originalConsoleError = console.error;
+    console.error = () => {};
+    try {
+      dispatchSubmit(root);
+    } finally {
+      console.error = originalConsoleError;
+    }
+
+    assert.deepEqual(calls, { save: 1, undo: 1, sync: 1, refresh: 1, change: 1 });
+    assert.equal(controller.isOpen(), true);
+    assert.match(latestNotice(root).textContent, /生成に失敗/);
+  })
+);
+
+test('app wires the grid frame modal and ignores Escape while IME is composing', async () => {
   const source = await readFile(new URL('../js/app.js', import.meta.url), 'utf8');
 
   assert.match(source, /import \{ initGridFrameModal \} from '\.\/grid-frame-modal\.js'/);
   assert.match(source, /const gridFrameModal = initGridFrameModal\(\{/);
   assert.match(source, /document\.getElementById\('btn-grid-frame'\).*gridFrameModal\.show/);
-  assert.match(source, /gridFrameModal\.applyLanguage\(\)/);
-  assert.match(source, /gridFrameModal\.isOpen\(\)/);
-  assert.match(source, /gridFrameModal\.hide\(\)/);
-  assert.match(source, /history\.setOnRestore\(\(\) => \{/);
-  assert.match(source, /syncSettingsControls\(\);\s*ui\.refreshLevelSelectors\(\);/);
+  assert.match(source, /if \(e\.isComposing\) return;\s*if \(e\.key === 'Escape'\)/);
 });
 
 test('in-app help documents generated and excluded model elements', async () => {

--- a/test/grid-frame-ui.test.js
+++ b/test/grid-frame-ui.test.js
@@ -1,0 +1,160 @@
+import test from 'node:test';
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+
+import { ToolManager } from '../js/tools.js';
+
+test('initial grid frame modal exposes all inputs and actions', async () => {
+  const html = await readFile(new URL('../index.html', import.meta.url), 'utf8');
+
+  for (const id of [
+    'btn-grid-frame',
+    'grid-frame-modal',
+    'grid-frame-form',
+    'grid-frame-story-heights',
+    'grid-frame-spans-x',
+    'grid-frame-spans-y',
+    'btn-grid-frame-close',
+    'btn-grid-frame-cancel',
+    'btn-grid-frame-generate',
+  ]) {
+    assert.match(html, new RegExp(`id="${id}"`));
+  }
+
+  assert.match(html, /data-i18n-placeholder="gridFrameStoryHeightsPlaceholder"/);
+  assert.match(html, /data-i18n-placeholder="gridFrameSpansXPlaceholder"/);
+  assert.match(html, /data-i18n-placeholder="gridFrameSpansYPlaceholder"/);
+});
+
+test('grid frame modal wires validation, replacement, and rollback flow', async () => {
+  const source = await readFile(new URL('../js/grid-frame-modal.js', import.meta.url), 'utf8');
+
+  assert.match(source, /parseMmList\(field\.input\.value, \{ maxCount: field\.maxCount \}\)/);
+  assert.match(source, /state\.nodes\.length > 0 \|\| state\.members\.length > 0/);
+  assert.match(source, /window\.confirm\(t\('gridFrameReplaceConfirm'\)\)/);
+  assert.match(source, /generatedModel = buildGridFrame\(values\)/);
+  assert.match(source, /history\.save\(\)/);
+  assert.match(source, /state\.loadJSON\(generatedModel\)/);
+  assert.match(source, /syncSettingsControls\(\)/);
+  assert.match(source, /refreshLevelSelectors\(\)/);
+  assert.match(source, /history\.undo\(\)/);
+  assert.match(source, /gridFrameDone/);
+  assert.match(source, /gridFrameTooLarge/);
+
+  assert.ok(
+    source.indexOf('generatedModel = buildGridFrame(values)') < source.indexOf('history.save()'),
+    'validation/build must finish before history.save() clears redo'
+  );
+});
+
+test('app wires the grid frame modal and Escape handling', async () => {
+  const source = await readFile(new URL('../js/app.js', import.meta.url), 'utf8');
+
+  assert.match(source, /import \{ initGridFrameModal \} from '\.\/grid-frame-modal\.js'/);
+  assert.match(source, /const gridFrameModal = initGridFrameModal\(\{/);
+  assert.match(source, /document\.getElementById\('btn-grid-frame'\).*gridFrameModal\.show/);
+  assert.match(source, /gridFrameModal\.applyLanguage\(\)/);
+  assert.match(source, /gridFrameModal\.isOpen\(\)/);
+  assert.match(source, /gridFrameModal\.hide\(\)/);
+  assert.match(source, /history\.setOnRestore\(\(\) => \{/);
+  assert.match(source, /syncSettingsControls\(\);\s*ui\.refreshLevelSelectors\(\);/);
+});
+
+test('in-app help documents generated and excluded model elements', async () => {
+  const source = await readFile(new URL('../js/help-content.js', import.meta.url), 'utf8');
+
+  assert.match(source, /初期モデル生成（格子フレーム）/);
+  assert.match(source, /GLの並進3方向を拘束した支点/);
+  assert.match(source, /床・荷重・ブレースは生成されません/);
+  assert.match(source, /Initial Model Generation \(Grid Frame\)/);
+  assert.match(source, /supports restrained in DX\/DY\/DZ at GL/);
+  assert.match(source, /Floors, loads, and braces are not generated/);
+});
+
+test('text-field undo and redo remain native while the grid modal is being edited', () => {
+  let undoCalls = 0;
+  let redoCalls = 0;
+  let updateCalls = 0;
+  let preventDefaultCalls = 0;
+  const manager = Object.create(ToolManager.prototype);
+  Object.assign(manager, {
+    state: { currentTool: 'member' },
+    history: {
+      undo() { undoCalls++; return true; },
+      redo() { redoCalls++; return true; },
+    },
+    onUpdate() { updateCalls++; },
+  });
+  const event = (key, shiftKey = false) => ({
+    key,
+    code: `Key${key.toUpperCase()}`,
+    ctrlKey: true,
+    metaKey: false,
+    shiftKey,
+    target: { tagName: 'INPUT', isContentEditable: false },
+    preventDefault() { preventDefaultCalls++; },
+  });
+
+  manager._onKeyDown(event('z'));
+  manager._onKeyDown(event('y'));
+  manager._onKeyDown(event('z', true));
+
+  assert.equal(undoCalls, 0);
+  assert.equal(redoCalls, 0);
+  assert.equal(updateCalls, 0);
+  assert.equal(preventDefaultCalls, 0);
+
+  manager._onKeyDown({
+    ...event('z'),
+    target: { tagName: 'BODY', isContentEditable: false },
+  });
+  assert.equal(undoCalls, 1);
+  assert.equal(updateCalls, 1);
+  assert.equal(preventDefaultCalls, 1);
+});
+
+test('text-field spaces and Enter are not captured by canvas shortcuts', () => {
+  let preventDefaultCalls = 0;
+  let finishPolylineCalls = 0;
+  const manager = Object.create(ToolManager.prototype);
+  Object.assign(manager, {
+    state: { currentTool: 'surface', surfaceDraftMode: 'polyline' },
+    _spaceDown: false,
+    _finishSurfacePolyline() { finishPolylineCalls++; },
+  });
+  const inputTarget = { tagName: 'INPUT', isContentEditable: false };
+
+  manager._onKeyDown({
+    key: ' ',
+    code: 'Space',
+    target: inputTarget,
+    preventDefault() { preventDefaultCalls++; },
+  });
+  manager._onKeyDown({
+    key: 'Enter',
+    code: 'Enter',
+    target: inputTarget,
+    preventDefault() { preventDefaultCalls++; },
+  });
+
+  assert.equal(manager._spaceDown, false);
+  assert.equal(finishPolylineCalls, 0);
+  assert.equal(preventDefaultCalls, 0);
+
+  manager._onKeyDown({
+    key: ' ',
+    code: 'Space',
+    target: { tagName: 'BODY', isContentEditable: false },
+    preventDefault() { preventDefaultCalls++; },
+  });
+  manager._onKeyDown({
+    key: 'Enter',
+    code: 'Enter',
+    target: { tagName: 'BODY', isContentEditable: false },
+    preventDefault() { preventDefaultCalls++; },
+  });
+
+  assert.equal(manager._spaceDown, true);
+  assert.equal(finishPolylineCalls, 1);
+  assert.equal(preventDefaultCalls, 1);
+});

--- a/test/history.test.js
+++ b/test/history.test.js
@@ -44,6 +44,29 @@ test('undo and redo return false when their stacks are empty', () => {
   assert.equal(history.redo(), false);
 });
 
+test('restore callback runs after successful undo and redo only', () => {
+  const state = new AppState();
+  const history = new History(state);
+  const restoredMemberCounts = [];
+  history.setOnRestore(() => restoredMemberCounts.push(state.members.length));
+
+  assert.equal(history.undo(), false);
+  assert.deepEqual(restoredMemberCounts, []);
+
+  const n1 = state.addNode(0, 0);
+  const n2 = state.addNode(5000, 0);
+  history.save();
+  state.addMember(n1.id, n2.id, { type: 'beam' });
+
+  assert.equal(history.undo(), true);
+  assert.equal(history.redo(), true);
+  assert.deepEqual(restoredMemberCounts, [0, 1]);
+
+  history.setOnRestore(null);
+  assert.equal(history.undo(), true);
+  assert.deepEqual(restoredMemberCounts, [0, 1]);
+});
+
 test('save clears the redo stack', () => {
   const state = new AppState();
   const history = new History(state);


### PR DESCRIPTION
## 概要
- 階高・X/Yスパンのリストから、レベル・通り芯・柱・梁・GL固定支点を一括生成する初期モデル機能を追加
- 入力検証、生成量上限、既存モデルの置換確認、Undo/Redo後のUI同期を実装
- 日英i18n、アプリ内ヘルプ、uvを使うローカル起動手順、計画チェックリストを更新

## 検証
- `npm test`（232 tests passed）
- `npm run lint:all`
- `npm run version:check`
- `git diff --check`
- ブラウザ手動確認: 2D/3D表示、レベル・通り芯、入力エラー、置換、Undo/Redo、autosave適格性、解析エクスポート、数量集計、モデルチェック

## スコープ
床・荷重・ブレースの自動生成は今回の対象外です。